### PR TITLE
Input format: add org mode

### DIFF
--- a/src/Patat/Presentation/Read.hs
+++ b/src/Patat/Presentation/Read.hs
@@ -38,6 +38,7 @@ readExtension fileExt = case fileExt of
     ".md"  -> Just $ Pandoc.readMarkdown Pandoc.def
     ".lhs" -> Just $ Pandoc.readMarkdown lhsOpts
     ""     -> Just $ Pandoc.readMarkdown Pandoc.def
+    ".org" -> Just $ Pandoc.readOrg Pandoc.def
     _      -> Nothing
 
   where


### PR DESCRIPTION
Unfortunately, pandoc doesn't seem to export its selection of drivers from file extensions (it's in `pandoc.hs` where the `main` resides). So we're down to adding extensions one by one. I'm starting with my favourite format.