### PR TITLE
make build reproducible with variation of TZ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SOURCE_DATE_EPOCH?=$(shell date '+%s' \
 					   --date="$(shell git log -1 --format=%cd --date=rfc)")
 
 # Prettify the date.
-SOURCE_DATE=$(shell env LC_ALL=C TZ=UTC date '+%B %d, %Y' -d "@${SOURCE_DATE_EPOCH}")
+SOURCE_DATE=$(shell env LC_ALL=C date --utc '+%B %d, %Y' -d "@${SOURCE_DATE_EPOCH}")
 
 extra/patat.1: README.md extra/make-man
 	SOURCE_DATE="$(SOURCE_DATE)" ./extra/make-man >$@

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SOURCE_DATE_EPOCH?=$(shell date '+%s' \
 					   --date="$(shell git log -1 --format=%cd --date=rfc)")
 
 # Prettify the date.
-SOURCE_DATE=$(shell env LC_ALL=C date '+%B %d, %Y' -d "@${SOURCE_DATE_EPOCH}")
+SOURCE_DATE=$(shell env LC_ALL=C TZ=UTC date '+%B %d, %Y' -d "@${SOURCE_DATE_EPOCH}")
 
 extra/patat.1: README.md extra/make-man
 	SOURCE_DATE="$(SOURCE_DATE)" ./extra/make-man >$@


### PR DESCRIPTION
https://tests.reproducible-builds.org/debian/rb-pkg/experimental/amd64/diffoscope-results/patat.html

`patat` is not reproducible yet. Based on the timestamp (1 day) and danielsh mentoring, it seems to indicates a timezone problem.