### PR TITLE
add: Move slides with PageUp and PageDown

### DIFF
--- a/src/Patat/Presentation/Interactive.hs
+++ b/src/Patat/Presentation/Interactive.hs
@@ -42,10 +42,14 @@ readPresentationCommand = do
         "j"      -> return SkipForward
         "k"      -> return SkipBackward
         "l"      -> return Forward
+        -- Arrow keys
         "\ESC[C" -> return Forward
         "\ESC[D" -> return Backward
         "\ESC[B" -> return SkipForward
         "\ESC[A" -> return SkipBackward
+        -- PageUp and PageDown
+        "\ESC[6" -> return Forward
+        "\ESC[5" -> return Backward
         "0"      -> return First
         "G"      -> return Last
         "r"      -> return Reload


### PR DESCRIPTION
* Add an ability to move slides with PageUp and PageDown.

* Add some comments.

Signed-off-by: mr.Shu <mr@shu.io>

----------------------------------------------------

@jaspervdj I am not sure if you are OK with this, but last time I used `patat`, I noticed that `PageUp` and `PageDown` (which are the keys emitted by many laser pointers) were ignored. This PR tries to fix that.