### PR TITLE
Add RGB support for themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ The accepted styles are:
 
 Also accepted are:
 
-`rgb#RGB`, `onRgb#RGB`, where `R` `G` and `B` are hexadecimal numbers (e.g. `rgb#f80` for orange).
+`rgb#RrGgBb`, `onRgb#RrGgBb`, where `Rr` `Gg` and `Bb` are hexadecimal bytes (e.g. `rgb#f08000` for orange).
 
 ### Syntax Highlighting
 

--- a/README.md
+++ b/README.md
@@ -410,6 +410,10 @@ The accepted styles are:
 `vividBlue`, `vividCyan`, `vividGreen`, `vividMagenta`, `vividRed`,
 `vividWhite`, `vividYellow`
 
+Also accepted are:
+
+`rgb#RGB`, `onRgb#RGB`, where `R` `G` and `B` are hexadecimal numbers (e.g. `rgb#f80` for orange).
+
 ### Syntax Highlighting
 
 As part of theming, syntax highlighting is also configurable.  This can be

--- a/patat.cabal
+++ b/patat.cabal
@@ -38,6 +38,7 @@ Executable patat
     base                 >= 4.6   && < 5,
     bytestring           >= 0.10  && < 0.11,
     containers           >= 0.5   && < 0.6,
+    colour               >= 2.3   && < 2.4,
     directory            >= 1.2   && < 1.4,
     filepath             >= 1.4   && < 1.5,
     mtl                  >= 2.2   && < 2.3,

--- a/tests/themes.md
+++ b/tests/themes.md
@@ -2,7 +2,7 @@
 patat:
   theme:
     bulletListMarkers: '-+'
-    emph: [onRgb#f80, underline]
+    emph: [onRgb#ff8800, underline]
 ...
 
 - This is a simple list.

--- a/tests/themes.md
+++ b/tests/themes.md
@@ -2,7 +2,7 @@
 patat:
   theme:
     bulletListMarkers: '-+'
-    emph: [onVividRed, underline]
+    emph: [onRgb#f80, underline]
 ...
 
 - This is a simple list.

--- a/tests/themes.md.dump
+++ b/tests/themes.md.dump
@@ -1,5 +1,5 @@
 [35m  - [0m[mThis is a simple list.[0m
-[m    [0m[35m  + [0m[mWith [0m[4;101mnested[0m[m items.[0m
+[m    [0m[35m  + [0m[mWith [0m[4;48;2;255;136;0mnested[0m[m items.[0m
 [m    [0m[35m  + [0m[mOne or two.[0m
 
 [35m  - [0m[mThe list theming is customized a bit.[0m


### PR DESCRIPTION
Hi! Love your project, great upgrade from `mdp` 😁

I added RGB support colors for themes, as supported by `System.Console.ANSI`.

The format used in the configuration YAML is the following:

```markdown
---
patat:
    theme:
        code:   [rgb#000, onRgb#aaa]
        emph:   [rgb#6af]
        header: [rgb#f80]
...

# An orange header!

I *love* `RGB`!
```

This renders as follows:

![image](https://user-images.githubusercontent.com/4116708/44603255-6b554d00-a7e2-11e8-82a5-5ceaf065a160.png)

The colors are triplets of bytes, mapping `#RGB` to `0xRRGGBB`, making for a total of 4096 different colors. Having this short format is enough for the purposes of text, is shorter to write, and also avoids a memory hog / freeze when opening `patat`: since `sgrsByName` contains all different SGR modes including the RGB ones, using the full space of `#RrGgBb` would generate 16 million entries (I tried, and it just freezes while loading for a very long time).

4096 colors is still quite a lot, so in order to avoid filling the screen with all of them for the error message, I filtered them out and added an explanation:

```bash
$ patat wrong.md
Error in $.theme.borders: Unknown style: "x". Known styles are: "bold", "dullBlack", ..., "vividYellow",
or "rgb#RGB" and "onRgb#RGB" where 'R', 'G' and 'B' are hexadecimal numbers (e.g. "rgb#f80").
```

I'm very far from being fluent in Haskell, so please point out anything that could be written better! This is actually my first Haskell open-source contribution. It's a simple feature but I spent many hours in `ghci` and reading the docs / source code of `System.Console.ANSI` and `Data.Colour` 😄