### PR TITLE
Extend theme to whole border

### DIFF
--- a/src/Patat/PrettyPrint.hs
+++ b/src/Patat/PrettyPrint.hs
@@ -17,6 +17,7 @@ module Patat.PrettyPrint
     , string
     , text
     , space
+    , spaces
     , softline
     , hardline
 
@@ -319,6 +320,11 @@ space = mkDoc Softspace
 
 
 --------------------------------------------------------------------------------
+spaces :: Int -> Doc
+spaces n = mconcat $ replicate n space
+
+
+--------------------------------------------------------------------------------
 softline :: Doc
 softline = mkDoc Softline
 
@@ -383,15 +389,15 @@ align width alignment doc0 =
 
     alignLine :: [Chunk] -> [Chunk]
     alignLine line =
-        let actual   = lineWidth line
-            spaces n = [StringChunk [] (replicate n ' ')] in
+        let actual        = lineWidth line
+            chunkSpaces n = [StringChunk [] (replicate n ' ')] in
         case alignment of
-            AlignLeft   -> line <> spaces (width - actual)
-            AlignRight  -> spaces (width - actual) <> line
+            AlignLeft   -> line <> chunkSpaces (width - actual)
+            AlignRight  -> chunkSpaces (width - actual) <> line
             AlignCenter ->
                 let r = (width - actual) `div` 2
                     l = (width - actual) - r in
-                spaces l <> line <> spaces r
+                chunkSpaces l <> line <> chunkSpaces r
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Applies the colors for the `border` attribute of the theme to the whole border instead of just the text:

<img width="962" alt="screen shot 2018-08-26 at 11 26 39" src="https://user-images.githubusercontent.com/4116708/44680992-88d32280-aa3f-11e8-8e15-8ed24d719111.png">
