### PR TITLE
Fix centered titles not being centered

### DIFF
--- a/src/Patat/Presentation/Display.hs
+++ b/src/Patat/Presentation/Display.hs
@@ -110,11 +110,12 @@ displayPresentation mbImages pres@Presentation {..} =
             prettyFragment theme fragment
         Just (ActiveTitle   block)    ->
             displayWithBorders pres $ \canvasSize theme ->
-            let pblock         = prettyBlock theme block
-                (prows, pcols) = PP.dimensions pblock
-                offsetRow      = (csRows canvasSize `div` 2) - (prows `div` 2)
-                offsetCol      = (csCols canvasSize `div` 2) - (pcols `div` 2)
-                spaces         = PP.NotTrimmable $ PP.spaces offsetCol in
+            let pblock          = prettyBlock theme block
+                (prows, pcols)  = PP.dimensions pblock
+                (mLeft, mRight) = marginsOf pSettings
+                offsetRow       = (csRows canvasSize `div` 2) - (prows `div` 2)
+                offsetCol       = ((csCols canvasSize - mLeft - mRight) `div` 2) - (pcols `div` 2)
+                spaces          = PP.NotTrimmable $ PP.spaces offsetCol in
             mconcat (replicate (offsetRow - 3) PP.hardline) <$$>
             PP.indent spaces spaces pblock
 


### PR DESCRIPTION
When using two levels of headers, level 1 headers become slides with a centered title.

However, #49 introduced a bug where margins are added left and right, but the number of spaces added to the left of the centered title don't account for those margins, resulting in all titles being totally off-center to the right.