### PR TITLE
Nix: bump upper skylighting dependency to < 0.9 to fix nixpkgs failing to build patat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- 0.8.2.4 (2019-08-12)
+    * Bump upper `skylighting` dependency to `< 0.9`
+
 - 0.8.2.3 (2019-06-25)
     * Bump upper `pandoc` dependency to 2.8
 

--- a/patat.cabal
+++ b/patat.cabal
@@ -1,5 +1,5 @@
 Name:                patat
-Version:             0.8.2.3
+Version:             0.8.2.4
 Synopsis:            Terminal-based presentations using Pandoc
 Description:         Terminal-based presentations using Pandoc.
 License:             GPL-2
@@ -46,7 +46,7 @@ Executable patat
     optparse-applicative >= 0.12  && < 0.15,
     pandoc               >= 2.0.4 && < 2.8,
     process              >= 1.6   && < 1.7,
-    skylighting          >= 0.1   && < 0.8.2,
+    skylighting          >= 0.1   && < 0.9,
     terminal-size        >= 0.3   && < 0.4,
     text                 >= 1.2   && < 1.3,
     time                 >= 1.4   && < 1.10,


### PR DESCRIPTION
Closes https://github.com/jaspervdj/patat/issues/65 again.

While I'm not an expert on nixpkgs yet, I've got a feeling that lines like https://github.com/NixOS/nixpkgs/blob/208aad46916d97b5c2a094f630edb7e470254be8/pkgs/development/haskell-modules/configuration-hackage2nix.yaml#L1939 are going to be a problem for continually working with this project, for I believe nixpkgs uses the latest & greatest versions of things.

In this instance, `skylighting` was set to be `< 0.8.2` for the upper version bound, but if `0.8.2` is what nixpkgs only has `0.8.2`, then it'll fail to build.

I wonder how other projects handle this? This feels like it shouldn't be this way...