### PR TITLE
Fix tests, add pandoc version to --version

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -26,6 +26,7 @@ import           System.Directory             (doesFileExist,
                                                getModificationTime)
 import           System.Exit                  (exitFailure, exitSuccess)
 import qualified System.IO                    as IO
+import qualified Text.Pandoc                  as Pandoc
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
 
 
@@ -116,6 +117,7 @@ main = do
 
     when (oVersion options) $ do
         putStrLn (showVersion Paths_patat.version)
+        putStrLn $ "Using pandoc: " ++ Pandoc.pandocVersion
         exitSuccess
 
     filePath <- case oFilePath options of

--- a/tests/fragments.md
+++ b/tests/fragments.md
@@ -4,6 +4,7 @@ patat:
 ...
 
 - This list
+
 - is displayed
 
     * item


### PR DESCRIPTION
This fixes the issue reported in #70 by carefully crafting the input so
it yields the same output with both pandoc versions.  Since this is a
fragile process, I also added the pandoc version to `patat --version`.
This will allow us to later have separate tests per pandoc version.