### PR TITLE
Fix syntactically invalid doc comments

### DIFF
--- a/lib/Patat/Main.hs
+++ b/lib/Patat/Main.hs
@@ -178,13 +178,13 @@ main = do
 -- on the terminal.  Tries to restore the original state of the terminal as much
 -- as possible.
 interactively
-    -- | Reads a command from stdin (or from some other IO).  This will be
-    -- interrupted by 'killThread' when the application finishes.
     :: (IO.Handle -> IO a)
-    -- | Application to run.
+    -- ^ Reads a command from stdin (or from some other IO).  This will be
+    -- interrupted by 'killThread' when the application finishes.
     -> (Chan a -> IO ())
-    -- | Returns when application finishes.
+    -- ^ Application to run.
     -> IO ()
+    -- ^ Returns when application finishes.
 interactively reader app = bracket setup teardown $ \(_, _, _, chan) -> app chan
   where
     setup = do

--- a/lib/Patat/Theme.hs
+++ b/lib/Patat/Theme.hs
@@ -224,7 +224,7 @@ namedSgrs = M.fromList
     , name <- maybeToList (sgrToString sgr)
     ]
   where
-    -- | It doesn't really matter if we generate "too much" SGRs here since
+    -- It doesn't really matter if we generate "too much" SGRs here since
     -- 'sgrToString' will only pick the ones we support.
     knownSgrs =
         [ Ansi.SetColor l i c


### PR DESCRIPTION
I'm currently unable to install this package via nixpkgs, because it fails to build when it gets to the Haddock stage, throwing this error:

```
lib/Patat/Main.hs:180:5: error:
    parse error on input '-- | Reads a command from stdin (or from some other IO).  This will be
    -- interrupted by 'killThread' when the application finishes.’
    |
180 |     -- | Reads a command from stdin (or from some other IO).  This will be
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
```

After reading https://fintanh.github.io/posts/fishy-documentation.html, it seems the correct syntax for non-top-level doc-comments is `-- ^`.