### PR TITLE
Refactor implementation of fragments.

### DIFF
--- a/lib/Patat/Presentation/Instruction.hs
+++ b/lib/Patat/Presentation/Instruction.hs
@@ -1,0 +1,93 @@
+--------------------------------------------------------------------------------
+-- | The Pandoc AST is not extensible, so we need to use another way to model
+-- different parts of slides that we want to appear bit by bit.
+--
+-- We do this by modelling a slide as a list of instructions, that manipulate
+-- the contents on a slide in a (for now) very basic way.
+module Patat.Presentation.Instruction
+    ( Instructions
+    , fromList
+    , toList
+
+    , Instruction (..)
+    , numFragments
+
+    , Fragment (..)
+    , renderFragment
+    ) where
+
+import qualified Text.Pandoc as Pandoc
+
+newtype Instructions a = Instructions [Instruction a] deriving (Show)
+
+-- A smart constructor that guarantees some invariants:
+--
+--  *  No consecutive pauses.
+--  *  All pauses moved to the top level.
+--  *  No pauses at the end.
+fromList :: [Instruction a] -> Instructions a
+fromList = Instructions . go
+  where
+    go instrs = case break (not . isPause) instrs of
+        (_, [])             -> []
+        (_ : _, remainder)  -> Pause : go remainder
+        ([], x : remainder) -> x : go remainder
+
+toList :: Instructions a -> [Instruction a]
+toList (Instructions xs) = xs
+
+data Instruction a
+    -- Pause.
+    = Pause
+    -- Append items.
+    | Append [a]
+    -- Modify the last block with the provided instruction.
+    | ModifyLast (Instruction a)
+    deriving (Show)
+
+isPause :: Instruction a -> Bool
+isPause Pause = True
+isPause (Append _) = False
+isPause (ModifyLast i) = isPause i
+
+numPauses :: Instructions a -> Int
+numPauses (Instructions xs) = length $ filter isPause xs
+
+numFragments :: Instructions a -> Int
+numFragments = succ . numPauses
+
+newtype Fragment = Fragment [Pandoc.Block] deriving (Show)
+
+renderFragment :: Int -> Instructions Pandoc.Block -> Fragment
+renderFragment = \n (Instructions instrs) -> Fragment $ go [] n instrs
+  where
+    go acc _ []         = acc
+    go acc n (Pause : instrs) = if n <= 0 then acc else go acc (n - 1) instrs
+    go acc n (instr : instrs) = go (goBlocks instr acc) n instrs
+
+goBlocks :: Instruction Pandoc.Block -> [Pandoc.Block] -> [Pandoc.Block]
+goBlocks Pause xs = xs
+goBlocks (Append ys) xs = xs ++ ys
+goBlocks (ModifyLast f) xs
+    | null xs   = xs  -- Shouldn't happen unless instructions are malformed.
+    | otherwise = modifyLast (goBlock f) xs
+
+goBlock :: Instruction Pandoc.Block -> Pandoc.Block -> Pandoc.Block
+goBlock Pause x = x
+goBlock (Append ys) block = case block of
+    -- We can only append to a few specific block types for now.
+    Pandoc.BulletList xs -> Pandoc.BulletList $ xs ++ [ys]
+    Pandoc.OrderedList attr xs -> Pandoc.OrderedList attr $ xs ++ [ys]
+    _ -> block
+goBlock (ModifyLast f) block = case block of
+    -- We can only modify the last content of a few specific block types for
+    -- now.
+    Pandoc.BulletList xs -> Pandoc.BulletList $ modifyLast (goBlocks f) xs
+    Pandoc.OrderedList attr xs ->
+        Pandoc.OrderedList attr $ modifyLast (goBlocks f) xs
+    _ -> block
+
+modifyLast :: (a -> a) -> [a] -> [a]
+modifyLast f (x : y : zs) = x : modifyLast f (y : zs)
+modifyLast f (x : [])     = [f x]
+modifyLast _ []           = []

--- a/lib/Patat/Presentation/Internal.hs
+++ b/lib/Patat/Presentation/Internal.hs
@@ -17,7 +17,7 @@ module Patat.Presentation.Internal
     , ImageSettings (..)
 
     , Slide (..)
-    , Fragment (..)
+    , Instruction.Fragment (..)
     , Index
 
     , getSlide
@@ -29,17 +29,18 @@ module Patat.Presentation.Internal
 
 
 --------------------------------------------------------------------------------
-import           Control.Monad          (mplus)
-import qualified Data.Aeson.Extended    as A
-import qualified Data.Aeson.TH.Extended as A
-import qualified Data.Foldable          as Foldable
-import           Data.List              (intercalate)
-import           Data.Maybe             (fromMaybe, listToMaybe)
-import qualified Data.Text              as T
-import qualified Patat.Theme            as Theme
+import           Control.Monad                  (mplus)
+import qualified Data.Aeson.Extended            as A
+import qualified Data.Aeson.TH.Extended         as A
+import qualified Data.Foldable                  as Foldable
+import           Data.List                      (intercalate)
+import           Data.Maybe                     (fromMaybe, listToMaybe)
+import qualified Data.Text                      as T
+import qualified Patat.Presentation.Instruction as Instruction
+import qualified Patat.Theme                    as Theme
 import           Prelude
-import qualified Text.Pandoc            as Pandoc
-import           Text.Read              (readMaybe)
+import qualified Text.Pandoc                    as Pandoc
+import           Text.Read                      (readMaybe)
 
 
 --------------------------------------------------------------------------------
@@ -226,14 +227,9 @@ instance A.FromJSON ImageSettings where
 
 --------------------------------------------------------------------------------
 data Slide
-    = ContentSlide [Fragment]
+    = ContentSlide (Instruction.Instructions Pandoc.Block)
     | TitleSlide   Int [Pandoc.Inline]
     deriving (Show)
-
-
---------------------------------------------------------------------------------
-newtype Fragment = Fragment {unFragment :: [Pandoc.Block]}
-    deriving (Monoid, Semigroup, Show)
 
 
 --------------------------------------------------------------------------------
@@ -248,12 +244,14 @@ getSlide sidx = listToMaybe . drop sidx . pSlides
 
 --------------------------------------------------------------------------------
 numFragments :: Slide -> Int
-numFragments (ContentSlide fragments) = length fragments
-numFragments (TitleSlide _ _)         = 1
+numFragments (ContentSlide instrs) = Instruction.numFragments instrs
+numFragments (TitleSlide _ _)      = 1
 
 
 --------------------------------------------------------------------------------
-data ActiveFragment = ActiveContent Fragment | ActiveTitle Pandoc.Block
+data ActiveFragment
+    = ActiveContent Instruction.Fragment
+    | ActiveTitle Pandoc.Block
     deriving (Show)
 
 
@@ -262,11 +260,11 @@ getActiveFragment :: Presentation -> Maybe ActiveFragment
 getActiveFragment presentation = do
     let (sidx, fidx) = pActiveFragment presentation
     slide <- getSlide sidx presentation
-    case slide of
-        TitleSlide   lvl is    -> return . ActiveTitle $
+    pure $ case slide of
+        TitleSlide lvl is -> ActiveTitle $
             Pandoc.Header lvl Pandoc.nullAttr is
-        ContentSlide fragments ->
-            fmap ActiveContent . listToMaybe $ drop fidx fragments
+        ContentSlide instrs -> ActiveContent $
+            Instruction.renderFragment fidx instrs
 
 
 --------------------------------------------------------------------------------

--- a/lib/Patat/Presentation/Read.hs
+++ b/lib/Patat/Presentation/Read.hs
@@ -12,25 +12,27 @@ module Patat.Presentation.Read
 
 
 --------------------------------------------------------------------------------
-import           Control.Monad.Except        (ExceptT (..), runExceptT,
-                                              throwError)
-import           Control.Monad.Trans         (liftIO)
-import qualified Data.Aeson                  as A
-import           Data.Bifunctor              (first)
-import qualified Data.HashMap.Strict         as HMS
-import           Data.Maybe                  (fromMaybe)
-import qualified Data.Text                   as T
-import qualified Data.Text.Encoding          as T
-import qualified Data.Text.IO                as T
-import qualified Data.Yaml                   as Yaml
+import           Control.Monad.Except           (ExceptT (..), runExceptT,
+                                                 throwError)
+import           Control.Monad.Trans            (liftIO)
+import qualified Data.Aeson                     as A
+import           Data.Bifunctor                 (first)
+import qualified Data.HashMap.Strict            as HMS
+import           Data.Maybe                     (fromMaybe)
+import qualified Data.Text                      as T
+import qualified Data.Text.Encoding             as T
+import qualified Data.Text.IO                   as T
+import qualified Data.Yaml                      as Yaml
 import           Patat.Presentation.Fragment
+import qualified Patat.Presentation.Instruction as Instruction
 import           Patat.Presentation.Internal
 import           Prelude
-import           System.Directory            (doesFileExist, getHomeDirectory)
-import           System.FilePath             (splitFileName, takeExtension,
-                                              (</>))
-import qualified Text.Pandoc.Error           as Pandoc
-import qualified Text.Pandoc.Extended        as Pandoc
+import           System.Directory               (doesFileExist,
+                                                 getHomeDirectory)
+import           System.FilePath                (splitFileName, takeExtension,
+                                                 (</>))
+import qualified Text.Pandoc.Error              as Pandoc
+import qualified Text.Pandoc.Extended           as Pandoc
 
 
 --------------------------------------------------------------------------------
@@ -151,10 +153,8 @@ pandocToSlides settings pandoc =
         fragmented   =
             [ case slide of
                 TitleSlide   _ _        -> slide
-                ContentSlide fragments0 ->
-                    let blocks  = concatMap unFragment fragments0
-                        blockss = fragmentBlocks fragmentSettings blocks in
-                    ContentSlide (map Fragment blockss)
+                ContentSlide instrs0 -> ContentSlide $
+                    fragmentInstructions fragmentSettings instrs0
             | slide <- unfragmented
             ] in
     fragmented
@@ -193,7 +193,8 @@ splitSlides slideLevel (Pandoc.Pandoc _meta blocks0)
   where
     mkContentSlide :: [Pandoc.Block] -> [Slide]
     mkContentSlide [] = []  -- Never create empty slides
-    mkContentSlide bs = [ContentSlide [Fragment bs]]
+    mkContentSlide bs =
+        [ContentSlide $ Instruction.fromList [Instruction.Append bs]]
 
     splitAtRules blocks = case break (== Pandoc.HorizontalRule) blocks of
         (xs, [])           -> mkContentSlide xs

--- a/patat.cabal
+++ b/patat.cabal
@@ -73,6 +73,7 @@ Library
     Patat.Presentation.Display.CodeBlock
     Patat.Presentation.Display.Table
     Patat.Presentation.Fragment
+    Patat.Presentation.Instruction
     Patat.Presentation.Interactive
     Patat.Presentation.Internal
     Patat.Presentation.Read

--- a/tests/golden/outputs/fragments.md.dump
+++ b/tests/golden/outputs/fragments.md.dump
@@ -1,5 +1,4 @@
 
-
 [m~~~frag[0m
 [35m  - [0m[mThis list[0m
 
@@ -8,8 +7,6 @@
 [35m  - [0m[mThis list[0m
 
 [35m  - [0m[mis displayed[0m
-
-
 
 
 [m~~~frag[0m


### PR DESCRIPTION
Fragments deal with how content is shown piece by piece.  For example, if we
have the slide:

    Foo

    . . .

    Bar

There are two fragments.  First, only `Foo` is visible.  When the user goes
to the next fragment, `Foo` and `Bar` are both visible.

The first implementation of fragments in patat would compute the state of
all the visible items.  In this case, that would be:

1.  `[Foo]`
2.  `[Foo, Bar]`

This does not work elegantly if you want another pass to add further fragments:
you now need to split `Foo` in multiple places (and the thunk is no longer
shared).  This PR refactors this to use "instructions" over the slide content.
For the example, these instructions would be:

1.  `Append [Foo]`
2.  `Pause`
3.  `Append [Bar]`

The `Pause`s are explicit, and indicate how many fragments are present.

There are more constructors, for manipulation of lists which is necessary
if nested lists are shown incrementally.  This all for allows much nicer
manipulation of the fragments, which in turn is useful for #52.