### PR TITLE
Bump bytestring, tested to work on 0.11.3

### DIFF
--- a/patat.cabal
+++ b/patat.cabal
@@ -37,7 +37,7 @@ Library
     async                >= 2.2  && < 2.3,
     base                 >= 4.9  && < 5,
     base64-bytestring    >= 1.0  && < 1.3,
-    bytestring           >= 0.10 && < 0.11,
+    bytestring           >= 0.10 && < 0.12,
     colour               >= 2.3  && < 2.4,
     containers           >= 0.5  && < 0.7,
     directory            >= 1.2  && < 1.4,


### PR DESCRIPTION
On my Mac, patat would not install without bytestring>=0.11.3. I have tested that patat works with. bytestring==0.11.3 and bumped the version requirement.