### PR TITLE
Bump skylighting's restrictive upper bound to 0.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Installation
 - Ubuntu: <https://packages.ubuntu.com/bionic/patat>
 - openSUSE: <https://build.opensuse.org/package/show/openSUSE:Factory:ARM/patat>
 - Fedora: <https://src.fedoraproject.org/rpms/patat>
+- NixOS: <https://search.nixos.org/packages?show=haskellPackages.patat>
 
 You can also find generic Linux and Mac OS binaries here:
 <https://github.com/jaspervdj/patat/releases>.

--- a/patat.cabal
+++ b/patat.cabal
@@ -47,7 +47,7 @@ Library
     pandoc               >= 3.1  && < 3.2,
     pandoc-types         >= 1.23 && < 1.24,
     process              >= 1.6  && < 1.7,
-    skylighting          >= 0.10 && < 0.14,
+    skylighting          >= 0.10 && < 0.15,
     terminal-size        >= 0.3  && < 0.4,
     text                 >= 1.2  && < 2.1,
     time                 >= 1.4  && < 1.13,


### PR DESCRIPTION
Hi there!

This is a change to fix the nixpkgs build.   

On nixpkgs `patat` was configured to use `pandoc` version 3.1.6.1, as haskell-updates still brings in 3.0.1, and the latest Stackage bump updated the `pandoc` version to 3.1.8; which in turn requires the `skylighting` version to be greater or equal to 0.14.

I checked out `skylighting`'s changelog for things that could affect patat, and tried out the executable after the bump to see it still functions.