### PR TITLE
Add eval.wrap option

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,6 +586,8 @@ empty list `[]`.
 
 ### Images
 
+#### Native Images support
+
 `patat-0.8.0.0` and newer include images support for some terminal emulators.
 
 ```markdown
@@ -624,6 +626,33 @@ patat:
     path: '/home/jasper/.local/bin/w3mimgdisplay'
     ```
 
+#### Images using Evaluation
+
+Rather than using the built-in image support, you can also use programs that
+write ASCII escape codes directly to the screen with
+[code evaluation](#evaluating-code).
+
+In order to do that, for example, we could configure `kitten` code snippets
+to evaluate using [Kitty]'s command `icat`.  This uses the `rawInline` code
+setting to ensure that the resulting output is not wrapped in a code block,
+and the `fragment` and `replace` settings immediately replace the snippet.
+
+    ---
+    patat:
+      eval:
+        kitten:
+          command: sed 's/^/kitten /' | bash
+          replace: true
+          fragment: false
+          wrap: rawInline
+    ...
+
+    See, for example:
+
+    ```kitten
+    icat --align left dank-meme.jpg
+    ```
+
 ### Breadcrumbs
 
 By default, `patat` will print a breadcrumbs-style header, e.g.:
@@ -660,6 +689,7 @@ _evaluator_ by specifying this in the YAML metadata:
           command: irb --noecho --noverbose
           fragment: true  # Optional
           replace: false  # Optional
+          wrap: code  # Optional
     ...
 
     Here is an example of a code block that is evaluated:
@@ -681,6 +711,12 @@ Aside from the command, there are two more options:
     between showing the original code block and the output.  Defaults to `true`.
  -  `replace`: Remove the original code block and replace it with the output
     rather than appending the output in a new code block.  Defaults to `false`.
+ -  `wrap`: By default, the output is wrapped in a code block again with the
+    original syntax highlighting.  You can customize this behaviour by setting
+    `wrap` to:
+     *  `code`: the default setting.
+     *  `raw`: no formatting applied.
+     *  `rawInline`: no formatting applied and no trailing newline.
 
 Setting `fragment: false` and `replace: true` offers a way to "filter" code
 blocks, which can be used to render ASCII graphics.

--- a/lib/Patat/Presentation/Display.hs
+++ b/lib/Patat/Presentation/Display.hs
@@ -352,10 +352,11 @@ prettyInline ds (Pandoc.Image _attrs text (target, _title)) =
     "![" <> themed ds themeImageText (prettyInlines ds text) <> "](" <>
     themed ds themeImageTarget (PP.text target) <> ")"
 
+prettyInline _ (Pandoc.RawInline _ t) = PP.text t
+
 -- These elements aren't really supported.
 prettyInline ds  (Pandoc.Cite      _ t) = prettyInlines ds t
 prettyInline ds  (Pandoc.Span      _ t) = prettyInlines ds t
-prettyInline _ds (Pandoc.RawInline _ t) = PP.text t
 prettyInline ds  (Pandoc.Note        t) = prettyBlocks  ds t
 prettyInline ds  (Pandoc.Superscript t) = prettyInlines ds t
 prettyInline ds  (Pandoc.Subscript   t) = prettyInlines ds t

--- a/tests/golden/inputs/eval06.md
+++ b/tests/golden/inputs/eval06.md
@@ -1,0 +1,52 @@
+---
+patat:
+  eval:
+    shImplicit:
+      command: sh
+      wrap: code
+      replace: true
+      fragment: false
+    shCode:
+      command: sh
+      wrap: code
+      replace: true
+      fragment: false
+    shRaw:
+      command: sh
+      wrap: raw
+      replace: true
+      fragment: false
+    shInline:
+      command: sh
+      wrap: rawInline
+      replace: true
+      fragment: false
+...
+
+# Implicit eval slide
+
+~~~{.shImplicit}
+printf '\e[1;34m%-6s\e[m' "This is text"
+~~~
+
+# Code eval slide
+
+~~~{.shCode}
+printf '\e[1;34m%-6s\e[m' "This is text"
+~~~
+
+# Raw eval slide
+
+~~~{.shRaw}
+printf '\e[1;34m%-6s\e[m' "This is text"
+~~~
+
+Newline here...
+
+# Raw Inline eval slide
+
+~~~{.shInline}
+printf '\e[1;34m%-6s\e[m' "This is text"
+~~~
+
+No newline here...

--- a/tests/golden/outputs/eval06.md.dump
+++ b/tests/golden/outputs/eval06.md.dump
@@ -1,0 +1,41 @@
+[33m                               eval06.md                                [0m
+
+[34m# Implicit eval slide[0m
+
+[m   [0m[40;37m                        [0m
+[m   [0m[40;37m [1;34mThis is text[m [0m
+[m   [0m[40;37m                        [0m
+
+[33m                                                                  1 / 4 [0m
+
+[m{slide}[0m
+[33m                               eval06.md                                [0m
+
+[34m# Code eval slide[0m
+
+[m   [0m[40;37m                        [0m
+[m   [0m[40;37m [1;34mThis is text[m [0m
+[m   [0m[40;37m                        [0m
+
+[33m                                                                  2 / 4 [0m
+
+[m{slide}[0m
+[33m                               eval06.md                                [0m
+
+[34m# Raw eval slide[0m
+
+[m[1;34mThis is text[m[0m
+
+[mNewline here...[0m
+
+[33m                                                                  3 / 4 [0m
+
+[m{slide}[0m
+[33m                               eval06.md                                [0m
+
+[34m# Raw Inline eval slide[0m
+
+[m[1;34mThis is text[m[0m
+[mNo newline here...[0m
+
+[33m                                                                  4 / 4 [0m


### PR DESCRIPTION
This adds a new `wrap` section to the `eval` configuration.

By default, the output is wrapped in a code block again with the original syntax highlighting.  You can customize this behaviour by setting `wrap` to:

 *  `code`: the default setting.
 *  `raw`: no formatting applied.
 *  `rawInline`: no formatting applied and no trailing newline.

You can use `rawInline` to draw graphics.  In order to do that, for example, we could configure `kitten` code snippets to evaluate using [Kitty]'s command `icat`.  This uses the `rawInline` code setting to ensure that the resulting output is not wrapped in a code block, and the `fragment` and `replace` settings immediately replace the snippet:

    ---
    patat:
      eval:
        kitten:
          command: sed 's/^/kitten /' | bash
          replace: true
          fragment: false
          wrap: rawInline
    ...

    See, for example:

    ```kitten
    icat --align left dank-meme.jpg
    ```

[Kitty]: https://sw.kovidgoyal.net/kitty/