### PR TITLE
Allow configuring specific headers in theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,22 @@ and `onRgb#101060` for a deep purple background).  Naturally, your terminal
 needs to support 24-bit RGB for this to work.  When creating portable
 presentations, it might be better to stick with the named colours listed above.
 
+#### Theming headers
+
+In addition to `header`, individual headers can also be customized.  The
+configuration blocks under `headers` accepts a `style` list, a `prefix` string
+and an `underline` string that is repeated match the width of the header.
+
+```yaml
+patat:
+  theme:
+    headers:
+      h3:
+        style: [vividRed]
+        prefix: '### '
+        underline: '-~-~'
+```
+
 ### Syntax Highlighting
 
 `patat` uses [Kate] Syntax Highlighting files.  `patat` ships with support for

--- a/lib/Patat/Theme.hs
+++ b/lib/Patat/Theme.hs
@@ -3,7 +3,8 @@
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE TemplateHaskell            #-}
 module Patat.Theme
-    ( Theme (..)
+    ( HeaderTheme (..)
+    , Theme (..)
     , defaultTheme
 
     , Style (..)
@@ -32,9 +33,18 @@ import           Text.Read              (readMaybe)
 
 
 --------------------------------------------------------------------------------
+data HeaderTheme = HeaderTheme
+    { htStyle     :: !(Maybe Style)
+    , htPrefix    :: !(Maybe T.Text)
+    , htUnderline :: !(Maybe T.Text)
+    } deriving (Show)
+
+
+--------------------------------------------------------------------------------
 data Theme = Theme
     { themeBorders            :: !(Maybe Style)
     , themeHeader             :: !(Maybe Style)
+    , themeHeaders            :: !(Maybe (M.Map String HeaderTheme))
     , themeCodeBlock          :: !(Maybe Style)
     , themeBulletList         :: !(Maybe Style)
     , themeBulletListMarkers  :: !(Maybe T.Text)
@@ -65,6 +75,7 @@ instance Semigroup Theme where
     l <> r = Theme
         { themeBorders            = mplusOn   themeBorders
         , themeHeader             = mplusOn   themeHeader
+        , themeHeaders            = mappendOn themeHeaders
         , themeCodeBlock          = mplusOn   themeCodeBlock
         , themeBulletList         = mplusOn   themeBulletList
         , themeBulletListMarkers  = mplusOn   themeBulletListMarkers
@@ -99,13 +110,17 @@ instance Monoid Theme where
     mempty  = Theme
         Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
         Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
-        Nothing Nothing Nothing Nothing Nothing Nothing
+        Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 --------------------------------------------------------------------------------
 defaultTheme :: Theme
 defaultTheme = Theme
     { themeBorders            = dull Ansi.Yellow
     , themeHeader             = dull Ansi.Blue
+    , themeHeaders            = Just $ M.fromList $ do
+        n <- [1 .. 6]
+        let prefix = T.replicate n "#" <> " "
+        pure ("h" <> show n, HeaderTheme Nothing (Just prefix) Nothing)
     , themeCodeBlock          = dull Ansi.White `mappend` ondull Ansi.Black
     , themeBulletList         = dull Ansi.Magenta
     , themeBulletListMarkers  = Just "-*"
@@ -322,4 +337,5 @@ syntaxHighlight theme tokenType = do
 
 
 --------------------------------------------------------------------------------
+$(A.deriveJSON A.dropPrefixOptions ''HeaderTheme)
 $(A.deriveJSON A.dropPrefixOptions ''Theme)

--- a/tests/golden/inputs/theme-headers.md
+++ b/tests/golden/inputs/theme-headers.md
@@ -1,0 +1,23 @@
+---
+patat:
+  theme:
+    headers:
+      h1:
+        underline: "=~"
+      h3:
+        style: [vividRed]
+        prefix: '== '
+        underline: '^ '
+...
+
+# Header 1
+
+## Header 2
+
+### Header 3
+
+Some Content
+
+### A long Header 3
+
+More Content

--- a/tests/golden/outputs/theme-headers.md.dump
+++ b/tests/golden/outputs/theme-headers.md.dump
@@ -1,0 +1,48 @@
+[33m                            theme-headers.md                            [0m
+
+
+
+
+
+
+
+
+[m                                [0m[34mHeader 1[0m
+[m                                [0m[34m=~=~=~=~[0m
+
+[33m                                                                  1 / 4 [0m
+
+[m{slide}[0m
+[33m                      theme-headers.md > Header 1                       [0m
+
+
+
+
+
+
+
+
+
+[m                               [0m[34m## Header 2[0m
+
+[33m                                                                  2 / 4 [0m
+
+[m{slide}[0m
+[33m                 theme-headers.md > Header 1 > Header 2                 [0m
+
+[91m== Header 3[0m
+[91m^ ^ ^ ^ ^ ^[0m
+
+[mSome Content[0m
+
+[33m                                                                  3 / 4 [0m
+
+[m{slide}[0m
+[33m                 theme-headers.md > Header 1 > Header 2                 [0m
+
+[91m== A long Header 3[0m
+[91m^ ^ ^ ^ ^ ^ ^ ^ ^ [0m
+
+[mMore Content[0m
+
+[33m                                                                  4 / 4 [0m


### PR DESCRIPTION
In addition to `header`, individual headers can now also be customized.  The
configuration blocks under `headers` accepts a `style` list, a `prefix` string
and an `underline` string that is repeated match the width of the header.

For example:

```yaml
patat:
  theme:
    headers:
      h3:
        style: [vividRed]
        prefix: '### '
        underline: '-~-~'
```

See #81 