### PR TITLE
rename eval.wrap to eval.container

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ write ASCII escape codes directly to the screen with
 [code evaluation](#evaluating-code).
 
 In order to do that, for example, we could configure `kitten` code snippets
-to evaluate using [Kitty]'s command `icat`.  This uses the `rawInline` code
+to evaluate using [Kitty]'s command `icat`.  This uses the `none` container
 setting to ensure that the resulting output is not wrapped in a code block,
 and the `fragment` and `replace` settings immediately replace the snippet.
 
@@ -667,7 +667,7 @@ and the `fragment` and `replace` settings immediately replace the snippet.
           command: sed 's/^/kitten /' | bash
           replace: true
           fragment: false
-          wrap: rawInline
+          container: none
     ...
 
     See, for example:
@@ -712,7 +712,7 @@ _evaluator_ by specifying this in the YAML metadata:
           command: irb --noecho --noverbose
           fragment: true  # Optional
           replace: false  # Optional
-          wrap: code  # Optional
+          container: code  # Optional
     ...
 
     Here is an example of a code block that is evaluated:
@@ -728,18 +728,19 @@ attribute on a code block matches the evaluator, it will be used.
 code of presentations downloaded from the internet before running them if they
 contain `eval` settings.
 
-Aside from the command, there are two more options:
+Aside from the command, there are three more options:
 
  -  `fragment`: Introduce a pause (see [fragments](#fragmented-slides)) in
     between showing the original code block and the output.  Defaults to `true`.
  -  `replace`: Remove the original code block and replace it with the output
     rather than appending the output in a new code block.  Defaults to `false`.
- -  `wrap`: By default, the output is wrapped in a code block again with the
-    original syntax highlighting.  You can customize this behaviour by setting
-    `wrap` to:
+ -  `container`: By default, the output is wrapped in a code block again with
+    the original syntax highlighting.  You can customize this behaviour by
+    setting `container` to:
      *  `code`: the default setting.
-     *  `raw`: no formatting applied.
-     *  `rawInline`: no formatting applied and no trailing newline.
+     *  `none`: no formatting applied.
+     *  `inline`: no formatting applied and no trailing newline.
+ -  `wrap`: this is a deprecated name for `container`.
 
 Setting `fragment: false` and `replace: true` offers a way to "filter" code
 blocks, which can be used to render ASCII graphics.

--- a/README.md
+++ b/README.md
@@ -611,7 +611,7 @@ empty list `[]`.
 
 #### Native Images support
 
-`patat-0.8.0.0` and newer include images support for some terminal emulators.
+Version 0.8 and later include images support for some terminal emulators.
 
 ```markdown
 ---
@@ -740,7 +740,8 @@ Aside from the command, there are three more options:
      *  `code`: the default setting.
      *  `none`: no formatting applied.
      *  `inline`: no formatting applied and no trailing newline.
- -  `wrap`: this is a deprecated name for `container`.
+ -  `wrap`: this is a deprecated name for `container`, used in version 0.11 and
+    earlier.
 
 Setting `fragment: false` and `replace: true` offers a way to "filter" code
 blocks, which can be used to render ASCII graphics.

--- a/lib/Patat/Eval.hs
+++ b/lib/Patat/Eval.hs
@@ -72,10 +72,10 @@ evalBlock settings orig@(Pandoc.CodeBlock attr@(_, classes, _) txt)
                     evalCommand <> ": exit code " <> T.pack (show i) <> "\n" <>
                     erStderr
         let fmt = "eval"
-            blocks = case evalWrap of
-                EvalWrapCode      -> [Pandoc.CodeBlock attr out]
-                EvalWrapRaw       -> [Pandoc.RawBlock fmt out]
-                EvalWrapRawInline -> [Pandoc.Plain [Pandoc.RawInline fmt out]]
+            blocks = case evalContainer of
+                EvalContainerCode   -> [Pandoc.CodeBlock attr out]
+                EvalContainerNone   -> [Pandoc.RawBlock fmt out]
+                EvalContainerInline -> [Pandoc.Plain [Pandoc.RawInline fmt out]]
         pure $ case (evalFragment, evalReplace) of
             (False, True) -> [Append blocks]
             (False, False) -> [Append (orig : blocks)]

--- a/lib/Patat/Presentation/Settings.hs
+++ b/lib/Patat/Presentation/Settings.hs
@@ -255,19 +255,18 @@ instance A.FromJSON EvalSettings where
         <$> o A..:  "command"
         <*> o A..:? "replace"  A..!= False
         <*> o A..:? "fragment" A..!= True
-        <*> containerOrWrap o
+        <*> deprecated "wrap" "container" EvalContainerCode o
       where
-        -- "wrap" is the deprecated name for "container".
-        containerOrWrap o = do
-            mw <- o A..:? "wrap"
-            mc <- o A..:? "container"
-            case (mw, mc) of
+        deprecated old new def obj = do
+            mo <- obj A..:? old
+            mn <- obj A..:? new
+            case (mo, mn) of
                 (Just _, Just _)   -> fail $
-                    "EvalSettings: \"wrap\" (deprecated) and \"container\" " ++
-                    "are both specified, please remove \"wrap\""
-                (Just w, Nothing)  -> pure w
-                (Nothing, Just c)  -> pure c
-                (Nothing, Nothing) -> pure EvalContainerCode  -- Default
+                    show old ++ " (deprecated) and " ++ show new ++ " " ++
+                    "are both specified, please remove " ++ show old
+                (Just o, Nothing)  -> pure o
+                (Nothing, Just n)  -> pure n
+                (Nothing, Nothing) -> pure def
 
 
 --------------------------------------------------------------------------------

--- a/tests/golden/inputs/eval07.md
+++ b/tests/golden/inputs/eval07.md
@@ -7,17 +7,17 @@ patat:
       fragment: false
     shCode:
       command: sh
-      wrap: code
+      container: code
       replace: true
       fragment: false
-    shRaw:
+    shNone:
       command: sh
-      wrap: raw
+      container: none
       replace: true
       fragment: false
     shInline:
       command: sh
-      wrap: rawInline
+      container: inline
       replace: true
       fragment: false
 ...
@@ -34,15 +34,15 @@ printf '\e[1;34m%-6s\e[m' "This is text"
 printf '\e[1;34m%-6s\e[m' "This is text"
 ~~~
 
-# Raw eval slide
+# None eval slide
 
-~~~{.shRaw}
+~~~{.shNone}
 printf '\e[1;34m%-6s\e[m' "This is text"
 ~~~
 
 Newline here...
 
-# Raw Inline eval slide
+# Inline eval slide
 
 ~~~{.shInline}
 printf '\e[1;34m%-6s\e[m' "This is text"

--- a/tests/golden/outputs/eval07.md.dump
+++ b/tests/golden/outputs/eval07.md.dump
@@ -1,0 +1,41 @@
+[33m                               eval07.md                                [0m
+
+[34m# Implicit eval slide[0m
+
+[m   [0m[40;37m                        [0m
+[m   [0m[40;37m [1;34mThis is text[m [0m
+[m   [0m[40;37m                        [0m
+
+[33m                                                                  1 / 4 [0m
+
+[m{slide}[0m
+[33m                               eval07.md                                [0m
+
+[34m# Code eval slide[0m
+
+[m   [0m[40;37m                        [0m
+[m   [0m[40;37m [1;34mThis is text[m [0m
+[m   [0m[40;37m                        [0m
+
+[33m                                                                  2 / 4 [0m
+
+[m{slide}[0m
+[33m                               eval07.md                                [0m
+
+[34m# None eval slide[0m
+
+[m[1;34mThis is text[m[0m
+
+[mNewline here...[0m
+
+[33m                                                                  3 / 4 [0m
+
+[m{slide}[0m
+[33m                               eval07.md                                [0m
+
+[34m# Inline eval slide[0m
+
+[m[1;34mThis is text[m[0m
+[mNo newline here...[0m
+
+[33m                                                                  4 / 4 [0m


### PR DESCRIPTION
`wrap` is used at the top-level of settings for wrapping at a certain column, and inside `eval` to determine the type in which the result is "wrapped". Using the same name for both is confusing, so this adds `eval.container` as the new name for `eval.wrap`.  `eval.wrap` will continue to be supported for the forseeable future, but its use will be discouraged.

This also changes the values (again keeping the original ones for backwards-compat), so the complete changes to a configuration would be:

- `wrap: code` -> `container: code`
- `wrap: raw` -> `container: none`
- `wrap: rawInline` -> `container: inline`