### PR TITLE
Add support for loongarch

### DIFF
--- a/patat.cabal
+++ b/patat.cabal
@@ -112,7 +112,10 @@ Library
 
 Executable patat
   Main-is:          Main.hs
-  Ghc-options:      -Wall -threaded -rtsopts "-with-rtsopts=-N"
+  if arch(loongarch64)
+	  Ghc-options:      -Wall -threaded -rtsopts 
+  else
+	  Ghc-options:      -Wall -threaded -rtsopts "-with-rtsopts=-N"
   Hs-source-dirs:   src
   Default-language: Haskell2010
   Build-depends:    base, patat


### PR DESCRIPTION
Failed to compile on loongarch architecture, error details are linked below: [https://buildd.debian.org/status/fetch.php?pkg=patat&arch=loong64&ver=0.11.0.0-1&stamp=1714612433&raw=0](url). 
This PR solves the above problem, the exact cause can be found at the link:[[https://github.com/commercialhaskell/stack/issues/680](https://github.com/cdepillabout/termonad/pull/url)](url).