### PR TITLE
Bump dependencies to work with LTS 23

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727348695,
-        "narHash": "sha256-J+PeFKSDV+pHL7ukkfpVzCOO7mBSrrpJ3svwBFABbhI=",
+        "lastModified": 1741246872,
+        "narHash": "sha256-Q6pMP4a9ed636qilcYX8XUguvKl/0/LGXhHcRI91p0U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1925c603f17fc89f4c8f6bf6f631a802ad85d784",
+        "rev": "10069ef4cf863633f57238f179a0297de84bd8d3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "patat";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/patat.cabal
+++ b/patat.cabal
@@ -11,7 +11,7 @@ Copyright:     2016 Jasper Van der Jeugt
 Category:      Text
 Build-type:    Simple
 Cabal-version: >=1.10
-Tested-with:   GHC ==9.2.8 || ==9.4.8 || ==9.6.3 || ==9.8.1
+Tested-with:   GHC ==9.2.8 || ==9.4.8 || ==9.6.3 || ==9.8.1 || ==9.8.4
 
 Extra-source-files:
   CHANGELOG.md
@@ -33,7 +33,7 @@ Library
 
   Build-depends:
     aeson                >= 2.0   && < 2.3,
-    ansi-terminal        >= 0.6   && < 1.1,
+    ansi-terminal        >= 0.6   && < 1.2,
     ansi-wl-pprint       >= 0.6   && < 1.1,
     async                >= 2.2   && < 2.3,
     base                 >= 4.9   && < 5,
@@ -47,7 +47,7 @@ Library
     JuicyPixels          >= 3.3.3 && < 3.4,
     mtl                  >= 2.2   && < 2.4,
     optparse-applicative >= 0.16  && < 0.19,
-    pandoc               >= 3.1   && < 3.6,
+    pandoc               >= 3.1   && < 3.7,
     pandoc-types         >= 1.23  && < 1.24,
     process              >= 1.6   && < 1.7,
     random               >= 1.2   && < 1.3,
@@ -137,7 +137,7 @@ Executable patat-make-man
     containers   >= 0.6 && < 0.8,
     doctemplates >= 0.8 && < 0.12,
     mtl          >= 2.2 && < 2.4,
-    pandoc       >= 3.1 && < 3.6,
+    pandoc       >= 3.1 && < 3.7,
     text         >= 1.2 && < 2.2,
     time         >= 1.6 && < 1.13
 
@@ -155,13 +155,13 @@ Test-suite patat-tests
 
   Build-depends:
     patat,
-    ansi-terminal    >= 0.6  && < 1.1,
+    ansi-terminal    >= 0.6  && < 1.2,
     base             >= 4.8  && < 5,
     directory        >= 1.2  && < 1.4,
-    pandoc           >= 3.1  && < 3.6,
+    pandoc           >= 3.1  && < 3.7,
     tasty            >= 1.2  && < 1.6,
     tasty-hunit      >= 0.10 && < 0.11,
-    tasty-quickcheck >= 0.10 && < 0.11,
+    tasty-quickcheck >= 0.10 && < 0.12,
     text             >= 1.2  && < 2.2,
     QuickCheck       >= 2.8  && < 2.15
 


### PR DESCRIPTION
Hi there! 

As said in the commit description the latest Stackage bump breaks `patat` on `haskell-updates`, so this bumps a few dependencies. As far as I can tell things work as expected, and test still pass.

Please take a look and let me know if anything needs changing, I don't know what the timeline for that draft MR is; so might just add a patch with the diff from this PR to fix things until there's a release.