### PR TITLE
Fix case-insensitivity of class names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
- *  Fix case-insensitivity of class names for `eval` code blocks.
+ *  Fix case-insensitivity of class names for `eval` code blocks (#192).
     Class names are case-insensitive (like in HTML), but we were treating them
     as case-sensitive.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+ *  Fix case-insensitivity of class names for `eval` code blocks.
+    Class names are case-insensitive (like in HTML), but we were treating them
+    as case-sensitive.
+
 ## 0.15.1.0 (2025-04-26)
 
  *  Add a `syntax` option for `eval` blocks (#187).  This allows you to set

--- a/lib/Patat/Eval/Internal.hs
+++ b/lib/Patat/Eval/Internal.hs
@@ -8,12 +8,12 @@ module Patat.Eval.Internal
 
 
 --------------------------------------------------------------------------------
-import qualified Control.Concurrent.Async       as Async
-import qualified Data.HashMap.Strict            as HMS
-import qualified Data.Text                      as T
+import qualified Control.Concurrent.Async    as Async
+import           Data.CaseInsensitive        (CI)
+import qualified Data.HashMap.Strict         as HMS
+import qualified Data.Text                   as T
 import           Patat.Presentation.Settings
 import           Patat.Presentation.Syntax
-import qualified Text.Pandoc                    as Pandoc
 
 
 --------------------------------------------------------------------------------
@@ -24,7 +24,7 @@ type EvalBlocks = HMS.HashMap Var EvalBlock
 -- | Block that needs to be evaluated.
 data EvalBlock = EvalBlock
     { ebSettings :: !EvalSettings
-    , ebAttr     :: !Pandoc.Attr
+    , ebClasses  :: ![CI T.Text]
     , ebInput    :: !T.Text
     , ebAsync    :: !(Maybe (Async.Async ()))
     }
@@ -33,7 +33,7 @@ data EvalBlock = EvalBlock
 --------------------------------------------------------------------------------
 renderEvalBlock :: EvalBlock -> T.Text -> [Block]
 renderEvalBlock EvalBlock {..} out = case evalContainer ebSettings of
-    EvalContainerCode   -> [CodeBlock ("", classes, []) out]
+    EvalContainerCode   -> [CodeBlock classes out]
     EvalContainerNone   -> [RawBlock fmt out]
     EvalContainerInline -> [Plain [RawInline fmt out]]
   where
@@ -41,6 +41,4 @@ renderEvalBlock EvalBlock {..} out = case evalContainer ebSettings of
 
     -- The classes for the new code block are copied from the old one if
     -- unspecified, or the syntax specified in the eval settings.
-    classes = case evalSyntax ebSettings of
-        Nothing        -> let (_, cs, _) = ebAttr in cs
-        Just outSyntax -> [outSyntax]
+    classes = maybe ebClasses pure $ evalSyntax ebSettings

--- a/lib/Patat/Presentation/Display.hs
+++ b/lib/Patat/Presentation/Display.hs
@@ -282,7 +282,7 @@ prettyBlock ds (Header i _ inlines) =
     themed ds themeHeader (PP.string (replicate i '#') <+> prettyInlines ds inlines) <>
     PP.hardline
 
-prettyBlock ds (CodeBlock (_, classes, _) txt) =
+prettyBlock ds (CodeBlock classes txt) =
     prettyCodeBlock ds classes txt
 
 prettyBlock ds (BulletList bss) = PP.vcat

--- a/lib/Patat/Presentation/Display/CodeBlock.hs
+++ b/lib/Patat/Presentation/Display/CodeBlock.hs
@@ -8,6 +8,8 @@ module Patat.Presentation.Display.CodeBlock
 
 
 --------------------------------------------------------------------------------
+import           Data.CaseInsensitive                (CI)
+import qualified Data.CaseInsensitive                as CI
 import           Data.Char.WCWidth.Extended          (wcstrwidth, wcwidth)
 import           Data.Maybe                          (mapMaybe)
 import qualified Data.Text                           as T
@@ -20,7 +22,8 @@ import qualified Skylighting                         as Skylighting
 
 --------------------------------------------------------------------------------
 highlight
-    :: Skylighting.SyntaxMap -> [T.Text] -> T.Text -> [Skylighting.SourceLine]
+    :: Skylighting.SyntaxMap -> [CI T.Text] -> T.Text
+    -> [Skylighting.SourceLine]
 highlight extraSyntaxMap classes rawCodeBlock =
     case mapMaybe getSyntax classes of
         []        -> zeroHighlight rawCodeBlock
@@ -29,8 +32,9 @@ highlight extraSyntaxMap classes rawCodeBlock =
                 Left  _  -> zeroHighlight rawCodeBlock
                 Right sl -> sl
   where
-    getSyntax :: T.Text -> Maybe Skylighting.Syntax
-    getSyntax c = Skylighting.lookupSyntax c syntaxMap
+    -- Note that SyntaxMap always uses lowercase keys.
+    getSyntax :: CI T.Text -> Maybe Skylighting.Syntax
+    getSyntax c = Skylighting.lookupSyntax (T.toLower $ CI.original c) syntaxMap
 
     config :: Skylighting.TokenizerConfig
     config = Skylighting.TokenizerConfig
@@ -70,7 +74,7 @@ expandTabs tabStop = goTokens 0
 
 
 --------------------------------------------------------------------------------
-prettyCodeBlock :: DisplaySettings -> [T.Text] -> T.Text -> PP.Doc
+prettyCodeBlock :: DisplaySettings -> [CI T.Text] -> T.Text -> PP.Doc
 prettyCodeBlock ds classes rawCodeBlock =
     PP.vcat (map blockified sourceLines) <> PP.hardline
   where

--- a/lib/Patat/Presentation/Internal.hs
+++ b/lib/Patat/Presentation/Internal.hs
@@ -17,7 +17,7 @@ module Patat.Presentation.Internal
 
     , ImageSettings (..)
 
-    , EvalSettingsMap
+    , EvalSettingsMap (..)
     , EvalSettings (..)
 
     , Slide (..)

--- a/lib/Patat/Presentation/Syntax.hs
+++ b/lib/Patat/Presentation/Syntax.hs
@@ -38,6 +38,8 @@ module Patat.Presentation.Syntax
 import           Control.Monad.Identity      (runIdentity)
 import           Control.Monad.State         (State, execState, modify)
 import           Control.Monad.Writer        (Writer, execWriter, tell)
+import           Data.CaseInsensitive        (CI)
+import qualified Data.CaseInsensitive        as CI
 import           Data.Hashable               (Hashable)
 import qualified Data.HashSet                as HS
 import           Data.List                   (foldl')
@@ -68,7 +70,7 @@ data Block
     = Plain ![Inline]
     | Para ![Inline]
     | LineBlock ![[Inline]]
-    | CodeBlock !Pandoc.Attr !T.Text
+    | CodeBlock ![CI T.Text] !T.Text
     | RawBlock !Pandoc.Format !T.Text
     | BlockQuote ![Block]
     | OrderedList !Pandoc.ListAttributes ![[Block]]
@@ -194,7 +196,8 @@ fromPandocBlock (Pandoc.Plain xs) = [Plain (fromPandocInlines xs)]
 fromPandocBlock (Pandoc.Para xs) = [Para (fromPandocInlines xs)]
 fromPandocBlock (Pandoc.LineBlock xs) =
     [LineBlock (map fromPandocInlines xs)]
-fromPandocBlock (Pandoc.CodeBlock attrs body) = [CodeBlock attrs body]
+fromPandocBlock (Pandoc.CodeBlock (_, classes, _) body) =
+    [CodeBlock (map CI.mk classes) body]
 fromPandocBlock (Pandoc.RawBlock fmt body)
     -- Parse config blocks.
     | fmt == "html"

--- a/patat.cabal
+++ b/patat.cabal
@@ -39,6 +39,7 @@ Library
     base                 >= 4.9   && < 5,
     base64-bytestring    >= 1.0   && < 1.3,
     bytestring           >= 0.10  && < 0.13,
+    case-insensitive     >= 1.2   && < 1.3,
     colour               >= 2.3   && < 2.4,
     containers           >= 0.5   && < 0.7,
     directory            >= 1.2   && < 1.4,

--- a/tests/golden/dump.in/eval-case-insensitive.md
+++ b/tests/golden/dump.in/eval-case-insensitive.md
@@ -1,0 +1,11 @@
+---
+patat:
+  eval:
+    bAsH:
+      command: bash
+      fragment: false
+...
+
+```BaSh
+echo foo
+```

--- a/tests/golden/dump.out/eval-case-insensitive.md.dump
+++ b/tests/golden/dump.out/eval-case-insensitive.md.dump
@@ -1,0 +1,11 @@
+[33m                        eval-case-insensitive.md                        [0m
+
+[m   [0m[40;37m          [0m
+[m   [0m[40;37m echo foo [0m
+[m   [0m[40;37m          [0m
+
+[m   [0m[40;37m     [0m
+[m   [0m[40;37m foo [0m
+[m   [0m[40;37m     [0m
+
+[33m                                                                  1 / 1 [0m


### PR DESCRIPTION
Fix case-insensitivity of class names for `eval` code blocks (#192).
Class names are case-insensitive (like in HTML), but we were treating them
as case-sensitive.

See also #191.