### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,7 +141,7 @@
     column, and inside `eval` to determine the type in which the result
     is "wrapped". Using the same name for both is confusing, so this adds
     `eval.container` as the new name for `eval.wrap`. `eval.wrap` will continue
-    to be supported for the forseeable future, but its use will be discouraged.
+    to be supported for the foreseeable future, but its use will be discouraged.
 
     This also changes the values (again keeping the original ones for
     backwards-compat), so the complete changes to a configuration would be:
@@ -386,7 +386,7 @@
 
 ## 0.8.6.1 (2020-09-18)
 
-* Fix issue with laziness for evaluted code blocks, they should only be
+* Fix issue with laziness for evaluated code blocks, they should only be
   evaluated when we actually want to show them
 * Bump stack resolver to `lts-16.9`
 

--- a/lib/Patat/Presentation/Read.hs
+++ b/lib/Patat/Presentation/Read.hs
@@ -231,7 +231,7 @@ detectSlideLevel blocks0 =
 
 
 --------------------------------------------------------------------------------
--- | Split a pandoc document into slides.  If the document contains horizonal
+-- | Split a pandoc document into slides.  If the document contains horizontal
 -- rules, we use those as slide delimiters.  If there are no horizontal rules,
 -- we split using headers, determined by the slide level (see
 -- 'detectSlideLevel').

--- a/lib/Patat/Presentation/Syntax.hs
+++ b/lib/Patat/Presentation/Syntax.hs
@@ -295,7 +295,7 @@ newtype RevealID = RevealID Unique deriving (Eq, Ord, Show)
 -- a counter state.
 --
 -- The easiest example to think about is a bullet list which appears
--- incrmentally on a slide.  Initially, the counter state is 0.  As it is
+-- incrementally on a slide.  Initially, the counter state is 0.  As it is
 -- incremented (the user goes to the next fragment in the slide), more list
 -- items become visible.
 data RevealSequence a = RevealSequence


### PR DESCRIPTION
Found via `typos --hidden --format brief`