### PR TITLE
Make link rendering more configurable

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/README.md
+++ b/README.md
@@ -937,7 +937,9 @@ all transition effects using their respective default settings.
 
 ### Links
 
-Version 0.15.0.0 and later support [OSC8] for hyperlinks.  This makes hyperlinks
+#### OSC8
+
+Version 0.15 and later support [OSC8] for hyperlinks.  This makes hyperlinks
 clickable in many terminal emulators (see [OSC8 adoption]).
 
 There is currently no way to detect if a terminal supports this feature, so you
@@ -951,6 +953,24 @@ patat:
 
 [OSC8]: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
 [OSC8 adoption]: https://github.com/Alhadis/OSC8-Adoption
+
+#### Placement
+
+Version 0.16 and later support link placement.
+
+ -  `reference` (default): show URLs reference-style at the bottom of each
+    slide.
+ -  `drop`: Do not show the URLs at all (this only makes sense if [OSC8](#OSC8)
+    is turned on).
+
+For example:
+
+```yaml
+patat:
+  links:
+    osc8: true
+    placement: drop
+```
 
 Trivia
 ------

--- a/flake.nix
+++ b/flake.nix
@@ -18,12 +18,13 @@
     devShells = {
       default = pkgs.mkShell {
         packages = [
+          haskell.ghc
+          haskell.goldplate
+          haskell.stylish-haskell
           pkgs.cabal-install
           pkgs.entr
           pkgs.wezterm
-          haskell.goldplate
-          haskell.stylish-haskell
-          (haskell.ghc.withPackages (p: inputs.self.packages.${system}.default.buildInputs))
+          pkgs.zlib
         ];
       };
     };

--- a/lib/Patat/Presentation/Display.hs
+++ b/lib/Patat/Presentation/Display.hs
@@ -59,16 +59,17 @@ displayWithBorders (Size rows columns) pres@Presentation {..} f =
     borders (PP.space <> PP.string author <> middleSpaces <> PP.string active <> PP.space) <>
     PP.hardline
   where
-    -- Get terminal width/title
-    settings     = activeSettings pres
+    settings@PresentationSettings {..} = activeSettings pres
+
     (sidx, _)    = pActiveFragment
     ds           = DisplaySettings
         { dsSize          = canvasSize
         , dsMargins       = margins settings
-        , dsWrap          = fromMaybe NoWrap $ psWrap settings
-        , dsTabStop       = maybe 4 A.unFlexibleNum $ psTabStop settings
-        , dsOSC8          = fromMaybe False (psLinks settings >>= lsOSC8)
-        , dsTheme         = fromMaybe Theme.defaultTheme (psTheme settings)
+        , dsWrap          = fromMaybe NoWrap psWrap
+        , dsTabStop       = maybe 4 A.unFlexibleNum psTabStop
+        , dsOSC8          = fromMaybe False (psLinks >>= lsOSC8)
+        , dsLinkPlacement = fromMaybe ReferenceLinkPlacement (psLinks >>= lsPlacement)
+        , dsTheme         = fromMaybe Theme.defaultTheme psTheme
         , dsSyntaxMap     = pSyntaxMap
         , dsResolve       = \var -> fromMaybe [] $ HMS.lookup var pVars
         , dsRevealState   = revealState
@@ -87,9 +88,9 @@ displayWithBorders (Size rows columns) pres@Presentation {..} f =
         , s <- [" > ", PP.toString b]
         ]
     title
-        | not . fromMaybe True $ psBreadcrumbs settings = plainTitle
-        | wcstrwidth breadTitle > columns               = plainTitle
-        | otherwise                                     = breadTitle
+        | not . fromMaybe True $ psBreadcrumbs = plainTitle
+        | wcstrwidth breadTitle > columns      = plainTitle
+        | otherwise                            = breadTitle
 
     -- Dimensions of title.
     titleWidth  = wcstrwidth title
@@ -101,8 +102,8 @@ displayWithBorders (Size rows columns) pres@Presentation {..} f =
 
     -- Compute footer.
     active
-        | fromMaybe True $ psSlideNumber settings = show (sidx + 1) ++ " / " ++ show (length pSlides)
-        | otherwise                               = ""
+        | fromMaybe True psSlideNumber = show (sidx + 1) ++ " / " ++ show (length pSlides)
+        | otherwise                    = ""
     activeWidth  = wcstrwidth active
     author       = PP.toString (prettyInlines ds pAuthor)
     authorWidth  = wcstrwidth author
@@ -187,6 +188,7 @@ prettyMargins :: DisplaySettings -> [Block] -> PP.Doc
 prettyMargins ds blocks = vertical $
     map horizontal blocks ++
     case prettyReferences ds blocks of
+        _ | DropLinkPlacement <- dsLinkPlacement ds -> []
         []   -> []
         refs ->
             let doc0        = PP.vcat refs
@@ -497,10 +499,11 @@ prettyReferences ds =
     prettyReference :: Reference -> PP.Doc
     prettyReference (text, target, title) =
         "[" <>
-        themed ds themeLinkText
-            (prettyInlines ds $ newlineToSpace text) <>
+        (themed ds themeLinkText $
+            hyperlink ds target $ Just $
+                prettyInlines ds $ newlineToSpace text) <>
         "]: " <>
-        themed ds themeLinkTarget (PP.text target) <>
+        (themed ds themeLinkTarget $ hyperlink ds target Nothing) <>
         (if T.null title
             then mempty
             else PP.space <> PP.text title)
@@ -524,8 +527,9 @@ toReferenceLink _ = Nothing
 --------------------------------------------------------------------------------
 hyperlink :: DisplaySettings -> T.Text -> Maybe PP.Doc -> PP.Doc
 hyperlink ds url Nothing
-    | dsOSC8 ds = PP.hyperlink (T.unpack url) (PP.text url)
+    | dsOSC8 ds = themed ds themeLinkOSC8 $
+                    PP.hyperlink (T.unpack url) (PP.text url)
     | otherwise = PP.text url
 hyperlink ds url (Just doc)
-    | dsOSC8 ds = PP.hyperlink (T.unpack url) doc
+    | dsOSC8 ds = themed ds themeLinkOSC8 $ PP.hyperlink (T.unpack url) doc
     | otherwise = doc

--- a/lib/Patat/Presentation/Display/Internal.hs
+++ b/lib/Patat/Presentation/Display/Internal.hs
@@ -7,7 +7,7 @@ module Patat.Presentation.Display.Internal
 
 --------------------------------------------------------------------------------
 import           Patat.Presentation.Internal (Margins)
-import           Patat.Presentation.Settings (Wrap)
+import           Patat.Presentation.Settings (Wrap, LinkPlacement)
 import           Patat.Presentation.Syntax   (Block, RevealState, Var)
 import qualified Patat.PrettyPrint           as PP
 import           Patat.Size                  (Size)
@@ -17,15 +17,16 @@ import qualified Skylighting                 as Skylighting
 
 --------------------------------------------------------------------------------
 data DisplaySettings = DisplaySettings
-    { dsSize        :: !Size
-    , dsWrap        :: !Wrap
-    , dsTabStop     :: !Int
-    , dsMargins     :: !Margins
-    , dsOSC8        :: !Bool
-    , dsTheme       :: !Theme.Theme
-    , dsSyntaxMap   :: !Skylighting.SyntaxMap
-    , dsResolve     :: !(Var -> [Block])
-    , dsRevealState :: !RevealState
+    { dsSize          :: !Size
+    , dsWrap          :: !Wrap
+    , dsTabStop       :: !Int
+    , dsMargins       :: !Margins
+    , dsOSC8          :: !Bool
+    , dsLinkPlacement :: !LinkPlacement
+    , dsTheme         :: !Theme.Theme
+    , dsSyntaxMap     :: !Skylighting.SyntaxMap
+    , dsResolve       :: !(Var -> [Block])
+    , dsRevealState   :: !RevealState
     }
 
 

--- a/lib/Patat/Presentation/Settings.hs
+++ b/lib/Patat/Presentation/Settings.hs
@@ -25,6 +25,7 @@ module Patat.Presentation.Settings
 
     , TransitionSettings (..)
 
+    , LinkPlacement (..)
     , LinkSettings (..)
 
     , parseSlideSettings
@@ -314,22 +315,40 @@ instance A.FromJSON TransitionSettings where
 
 
 --------------------------------------------------------------------------------
+data LinkPlacement
+    = ReferenceLinkPlacement
+    | DropLinkPlacement
+    deriving (Eq, Show)
+
+
+--------------------------------------------------------------------------------
+instance A.FromJSON LinkPlacement where
+    parseJSON = A.withText "FromJSON LinkPlacement" $ \t -> case t of
+        "reference" -> pure ReferenceLinkPlacement
+        "drop"      -> pure DropLinkPlacement
+        _           -> fail $ "unknown placement: " <> show t
+
+
+--------------------------------------------------------------------------------
 data LinkSettings = LinkSettings
-    { lsOSC8 :: !(Maybe Bool)
+    { lsOSC8      :: !(Maybe Bool)
+    , lsPlacement :: !(Maybe LinkPlacement)
     } deriving (Eq, Show)
 
 
 --------------------------------------------------------------------------------
 instance Semigroup LinkSettings where
     l <> r = LinkSettings
-        { lsOSC8 = on mplus lsOSC8 l r
+        { lsOSC8      = on mplus lsOSC8      l r
+        , lsPlacement = on mplus lsPlacement l r
         }
 
 
 --------------------------------------------------------------------------------
 instance A.FromJSON LinkSettings where
-    parseJSON = A.withObject "FromJSON LinkSettings" $ \o ->
-        LinkSettings <$> o A..:? "osc8"
+    parseJSON = A.withObject "FromJSON LinkSettings" $ \o -> LinkSettings
+        <$> o A..:? "osc8"
+        <*> o A..:? "placement"
 
 
 --------------------------------------------------------------------------------

--- a/lib/Patat/Theme.hs
+++ b/lib/Patat/Theme.hs
@@ -234,6 +234,7 @@ data Theme = Theme
     , themeCode               :: !(Maybe Style)
     , themeLinkText           :: !(Maybe Style)
     , themeLinkTarget         :: !(Maybe Style)
+    , themeLinkOSC8           :: !(Maybe Style)  -- Undocumented
     , themeStrikeout          :: !(Maybe Style)
     , themeQuoted             :: !(Maybe Style)
     , themeMath               :: !(Maybe Style)
@@ -265,6 +266,7 @@ instance Semigroup Theme where
         , themeCode               = mplusOn   themeCode
         , themeLinkText           = mplusOn   themeLinkText
         , themeLinkTarget         = mplusOn   themeLinkTarget
+        , themeLinkOSC8           = mplusOn   themeLinkOSC8
         , themeStrikeout          = mplusOn   themeStrikeout
         , themeQuoted             = mplusOn   themeQuoted
         , themeMath               = mplusOn   themeMath
@@ -283,7 +285,7 @@ instance Monoid Theme where
     mempty  = Theme
         Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
         Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
-        Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+        Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 --------------------------------------------------------------------------------
 defaultTheme :: Theme
@@ -310,6 +312,7 @@ defaultTheme = Theme
     , themeCode               = dull Ansi.White `mappend` ondull Ansi.Black
     , themeLinkText           = dull Ansi.Green
     , themeLinkTarget         = dull Ansi.Cyan `mappend` underline
+    , themeLinkOSC8           = underline
     , themeStrikeout          = ondull Ansi.Red
     , themeQuoted             = dull Ansi.Green
     , themeMath               = dull Ansi.Green

--- a/tests/golden/dump.in/links.md
+++ b/tests/golden/dump.in/links.md
@@ -36,3 +36,39 @@ Some more links:
 Some more advanced stuff:
 
 [a **bold**, _italic_, `code` link](http://example.com#fmt)
+
+---
+
+<!--config:
+  links:
+    osc8: true
+    placement: drop
+-->
+
+With `placement: drop`:
+
+1.  An automatic one: <http://example.com#1>
+2.  An [inline one](http://example.com#2)
+3.  A [reference][ref] link
+4.  A [shortcut reference] link
+5.  A [titled] link
+
+[ref]: http://example.com#3
+[shortcut reference]: http://example.com#4
+[titled]: http://example.com#5 'The title'
+
+---
+
+<!--config:
+  theme:
+    linkOSC8: []
+  links:
+    osc8: true
+    placement: drop
+-->
+
+For the weird usecase you would want to turn of underlining OSC8 links?
+
+[not underlined](http://example.com#fmt)
+
+---

--- a/tests/golden/dump.out/links.md.dump
+++ b/tests/golden/dump.out/links.md.dump
@@ -10,31 +10,53 @@
 [m[[0m[32minline link[0m[m]: [0m[4;36m/url[0m
 [m[[0m[32mone with a title[0m[m]: [0m[4;36mhttp://fsf.org[0m[m click here for a good time![0m
 [m[[0m[32mfoo[0m[m]: [0m[4;36mhttp://foo.com/[0m
-[33m                                                                  1 / 3 [0m
+[33m                                                                  1 / 5 [0m
 
 [m{slide}[0m
 [33m                                links.md                                [0m
 
 [mSome more links:[0m
 
-[35m1.  [0m[mAn automatic one: <[0m[4;36m]8;id=0;http://example.com#1\http://example.com#1]8;;\[0m[m>[0m
-[35m2.  [0m[mAn [[0m[32m]8;id=1;http://example.com#2\inline one]8;;\[0m[m][0m
-[35m3.  [0m[mA [[0m[32m]8;id=2;http://example.com#3\reference]8;;\[0m[m] link[0m
-[35m4.  [0m[mA [[0m[32m]8;id=3;http://example.com#4\shortcut reference]8;;\[0m[m] link[0m
-[35m5.  [0m[mA [[0m[32m]8;id=4;http://example.com#5\titled]8;;\[0m[m] link[0m
+[35m1.  [0m[mAn automatic one: <[0m[4;36;4m]8;id=0;http://example.com#1\http://example.com#1]8;;\[0m[m>[0m
+[35m2.  [0m[mAn [[0m[32;4m]8;id=1;http://example.com#2\inline one]8;;\[0m[m][0m
+[35m3.  [0m[mA [[0m[32;4m]8;id=2;http://example.com#3\reference]8;;\[0m[m] link[0m
+[35m4.  [0m[mA [[0m[32;4m]8;id=3;http://example.com#4\shortcut reference]8;;\[0m[m] link[0m
+[35m5.  [0m[mA [[0m[32;4m]8;id=4;http://example.com#5\titled]8;;\[0m[m] link[0m
 
-[m[[0m[32minline one[0m[m]: [0m[4;36mhttp://example.com#2[0m
-[m[[0m[32mreference[0m[m]: [0m[4;36mhttp://example.com#3[0m
-[m[[0m[32mshortcut reference[0m[m]: [0m[4;36mhttp://example.com#4[0m
-[m[[0m[32mtitled[0m[m]: [0m[4;36mhttp://example.com#5[0m[m The title[0m
-[33m                                                                  2 / 3 [0m
+[m[[0m[32;4m]8;id=5;http://example.com#2\inline one]8;;\[0m[m]: [0m[4;36;4m]8;id=6;http://example.com#2\http://example.com#2]8;;\[0m
+[m[[0m[32;4m]8;id=7;http://example.com#3\reference]8;;\[0m[m]: [0m[4;36;4m]8;id=8;http://example.com#3\http://example.com#3]8;;\[0m
+[m[[0m[32;4m]8;id=9;http://example.com#4\shortcut reference]8;;\[0m[m]: [0m[4;36;4m]8;id=10;http://example.com#4\http://example.com#4]8;;\[0m
+[m[[0m[32;4m]8;id=11;http://example.com#5\titled]8;;\[0m[m]: [0m[4;36;4m]8;id=12;http://example.com#5\http://example.com#5]8;;\[0m[m The title[0m
+[33m                                                                  2 / 5 [0m
 
 [m{slide}[0m
 [33m                                links.md                                [0m
 
 [mSome more advanced stuff:[0m
 
-[m[[0m[32m]8;id=5;http://example.com#fmt\a ]8;;\[0m[32;1;31m]8;id=5;http://example.com#fmt\bold]8;;\[0m[32m]8;id=5;http://example.com#fmt\, ]8;;\[0m[32;32m]8;id=5;http://example.com#fmt\italic]8;;\[0m[32m]8;id=5;http://example.com#fmt\, ]8;;\[0m[32;40;37m]8;id=5;http://example.com#fmt\ code ]8;;\[0m[32m]8;id=5;http://example.com#fmt\ link]8;;\[0m[m][0m
+[m[[0m[32;4m]8;id=13;http://example.com#fmt\a ]8;;\[0m[32;4;1;31m]8;id=13;http://example.com#fmt\bold]8;;\[0m[32;4m]8;id=13;http://example.com#fmt\, ]8;;\[0m[32;4;32m]8;id=13;http://example.com#fmt\italic]8;;\[0m[32;4m]8;id=13;http://example.com#fmt\, ]8;;\[0m[32;4;40;37m]8;id=13;http://example.com#fmt\ code ]8;;\[0m[32;4m]8;id=13;http://example.com#fmt\ link]8;;\[0m[m][0m
 
-[m[[0m[32ma [0m[32;1;31mbold[0m[32m, [0m[32;32mitalic[0m[32m, [0m[32;40;37m code [0m[32m link[0m[m]: [0m[4;36mhttp://example.com#fmt[0m
-[33m                                                                  3 / 3 [0m
+[m[[0m[32;4m]8;id=14;http://example.com#fmt\a ]8;;\[0m[32;4;1;31m]8;id=14;http://example.com#fmt\bold]8;;\[0m[32;4m]8;id=14;http://example.com#fmt\, ]8;;\[0m[32;4;32m]8;id=14;http://example.com#fmt\italic]8;;\[0m[32;4m]8;id=14;http://example.com#fmt\, ]8;;\[0m[32;4;40;37m]8;id=14;http://example.com#fmt\ code ]8;;\[0m[32;4m]8;id=14;http://example.com#fmt\ link]8;;\[0m[m]: [0m[4;36;4m]8;id=15;http://example.com#fmt\http://example.com#fmt]8;;\[0m
+[33m                                                                  3 / 5 [0m
+
+[m{slide}[0m
+[33m                                links.md                                [0m
+
+[mWith [0m[40;37m placement: drop [0m[m:[0m
+
+[35m1.  [0m[mAn automatic one: <[0m[4;36;4m]8;id=16;http://example.com#1\http://example.com#1]8;;\[0m[m>[0m
+[35m2.  [0m[mAn [[0m[32;4m]8;id=17;http://example.com#2\inline one]8;;\[0m[m][0m
+[35m3.  [0m[mA [[0m[32;4m]8;id=18;http://example.com#3\reference]8;;\[0m[m] link[0m
+[35m4.  [0m[mA [[0m[32;4m]8;id=19;http://example.com#4\shortcut reference]8;;\[0m[m] link[0m
+[35m5.  [0m[mA [[0m[32;4m]8;id=20;http://example.com#5\titled]8;;\[0m[m] link[0m
+
+[33m                                                                  4 / 5 [0m
+
+[m{slide}[0m
+[33m                                links.md                                [0m
+
+[mFor the weird usecase you would want to turn of underlining OSC8 links?[0m
+
+[m[[0m[32m]8;id=21;http://example.com#fmt\not underlined]8;;\[0m[m][0m
+
+[33m                                                                  5 / 5 [0m


### PR DESCRIPTION
1.  Allow configuring link placement:

     *  `reference` (default): show URLs reference-style at the bottom of each
        slide.
     *  `drop`: Do not show the URLs at all (this only makes sense if OSC8 is
        turned on).

    For example:

    ```yaml patat:
      links:
        osc8: true
        placement: drop
    ```

2.  In addition to rendering OSC8 URLs on the inline links, do the same for the ones in the reference section.

3.  Underline all OSC8 links.