### PR TITLE
Add class-based header theming, and alert style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## UNRELEASED
+
+ *  This allows you to customize elements (currently only headers) with specific
+    classes.  For example:
+
+    ```markdown
+    ---
+    patat:
+      theme:
+        class:
+          alert:
+            prefix: "⚠️ "
+            style: [vividRed]
+          info:
+            prefix: "💡 "
+            style: [dullYellow]
+    ...
+
+    # Dynamically Typed Languages {.alert}
+
+    A dynamically typed language is a programming language where type checking
+    is performed at runtime (during execution) rather than beforehand.
+    ```
+
+    Note that `.alert` is already included in the default theme, so that will
+    work out of the box.
+
 ## 0.15.2.0 (2025-08-06)
 
  *  Fix case-insensitivity of class names for `eval` code blocks (#192).

--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ classes.
 patat:
   theme:
     class:
-      warning:
+      alert:
         prefix: "⚠ "
         style: [vividRed]
       info:
@@ -566,13 +566,13 @@ patat:
         style: [dullYellow]
 ...
 
-# Dynamically Typed Languages {.warning}
+# Dynamically Typed Languages {.alert}
 
 A dynamically typed language is a programming language where type checking is
 performed at runtime (during execution) rather than beforehand.
 ```
 
-Note that `.warning` is already included in the default theme, so that will
+Note that `.alert` is already included in the default theme, so that will
 work out of the box.
 
 ### Syntax Highlighting

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Table of Contents
     -   [Advanced slide splitting](#advanced-slide-splitting)
     -   [Fragmented slides](#fragmented-slides)
     -   [Theming](#theming)
+        -   [Theming headers](#theming-headers)
+        -   [Class-based theming](#class-based-theming)
     -   [Syntax Highlighting](#syntax-highlighting)
     -   [Pandoc Extensions](#pandoc-extensions)
     -   [Images](#images)
@@ -544,6 +546,37 @@ patat:
         underline: '-~-~'
         align: center
 ```
+
+#### Class-based theming
+
+Version 0.15.3 and later support class-based theming.  This allows you to
+customize elements (currently only [headers](#theming-headers)) with specific
+classes.
+
+```markdown
+---
+patat:
+  theme:
+    class:
+      warning:
+        prefix: "⚠ "
+        style: [vividRed]
+      info:
+        prefix: "💡 "
+        style: [dullYellow]
+...
+
+# Dynamically Typed Languages {.warning}
+
+A dynamically typed language is a programming language where type checking is
+performed at runtime (during execution) rather than beforehand.
+```
+
+Note that `.warning` is already included in the default theme, so that will
+work out of the box.
+
+# Dynamically Typed Languages {.warning}
+
 
 ### Syntax Highlighting
 

--- a/README.md
+++ b/README.md
@@ -575,9 +575,6 @@ performed at runtime (during execution) rather than beforehand.
 Note that `.warning` is already included in the default theme, so that will
 work out of the box.
 
-# Dynamically Typed Languages {.warning}
-
-
 ### Syntax Highlighting
 
 `patat` uses [Kate] Syntax Highlighting files.  `patat` ships with support for

--- a/lib/Patat/Presentation/Display.hs
+++ b/lib/Patat/Presentation/Display.hs
@@ -278,9 +278,9 @@ prettyMargins ds blocks = vertical $
     -- Find the right margins for the specific block.  Currently, only headers
     -- can have different margins.
     marginsFor :: Block -> Margins
-    marginsFor (Header n _ _) = fromMaybe gmargins $ do
-        align <- Theme.htAlign $ Theme.themeForHeader n (dsTheme ds)
-        guard $ align == Theme.CenterHeaderAlign
+    marginsFor (Header n (_, classes, _) _) = fromMaybe gmargins $ do
+        align <- Theme.btAlign $ Theme.themeForHeader n classes (dsTheme ds)
+        guard $ align == Theme.CenterBlockAlign
         pure gmargins {mLeft = Auto, mRight = Auto}
     marginsFor _ = gmargins
 
@@ -293,7 +293,7 @@ prettyBlock ds (Plain inlines) = prettyInlines ds inlines
 prettyBlock ds (Para inlines) =
     prettyInlines ds inlines <> PP.hardline
 
-prettyBlock ds (Header n _ inlines) =
+prettyBlock ds (Header n (_, classes, _) inlines) =
     themed ds style content <> PP.hardline <>
     (case underline of
         Just t | t /= "" ->
@@ -301,14 +301,14 @@ prettyBlock ds (Header n _ inlines) =
             PP.hardline
         _ -> mempty)
   where
-    prefix    = fromMaybe mempty $ Theme.htPrefix headerTheme
+    prefix    = fromMaybe mempty $ Theme.btPrefix headerTheme
     content   = PP.text prefix <> prettyInlines ds inlines
     (_, cols) = PP.dimensions content
-    underline = Theme.htUnderline headerTheme
+    underline = Theme.btUnderline headerTheme
 
-    headerTheme = Theme.themeForHeader n (dsTheme ds)
+    headerTheme = Theme.themeForHeader n classes (dsTheme ds)
 
-    style _ = Theme.htStyle headerTheme
+    style _ = Theme.btStyle headerTheme
 
 prettyBlock ds (CodeBlock classes txt) =
     prettyCodeBlock ds classes txt

--- a/lib/Patat/Presentation/Settings.hs
+++ b/lib/Patat/Presentation/Settings.hs
@@ -193,26 +193,27 @@ instance A.FromJSON ExtensionList where
 defaultExtensionList :: ExtensionList
 defaultExtensionList = ExtensionList $
     Pandoc.readerExtensions Pandoc.def `mappend` Pandoc.extensionsFromList
-    [ Pandoc.Ext_yaml_metadata_block
-    , Pandoc.Ext_table_captions
-    , Pandoc.Ext_simple_tables
-    , Pandoc.Ext_multiline_tables
-    , Pandoc.Ext_grid_tables
-    , Pandoc.Ext_pipe_tables
-    , Pandoc.Ext_raw_html
-    , Pandoc.Ext_tex_math_dollars
-    , Pandoc.Ext_fenced_code_blocks
-    , Pandoc.Ext_fenced_code_attributes
-    , Pandoc.Ext_backtick_code_blocks
-    , Pandoc.Ext_inline_code_attributes
-    , Pandoc.Ext_fancy_lists
-    , Pandoc.Ext_four_space_rule
+    [ Pandoc.Ext_backtick_code_blocks
     , Pandoc.Ext_definition_lists
     , Pandoc.Ext_example_lists
-    , Pandoc.Ext_strikeout
-    , Pandoc.Ext_superscript
-    , Pandoc.Ext_subscript
+    , Pandoc.Ext_fancy_lists
+    , Pandoc.Ext_fenced_code_attributes
+    , Pandoc.Ext_fenced_code_blocks
+    , Pandoc.Ext_four_space_rule
+    , Pandoc.Ext_grid_tables
+    , Pandoc.Ext_header_attributes
+    , Pandoc.Ext_inline_code_attributes
+    , Pandoc.Ext_multiline_tables
+    , Pandoc.Ext_pipe_tables
+    , Pandoc.Ext_raw_html
     , Pandoc.Ext_shortcut_reference_links
+    , Pandoc.Ext_simple_tables
+    , Pandoc.Ext_strikeout
+    , Pandoc.Ext_subscript
+    , Pandoc.Ext_superscript
+    , Pandoc.Ext_table_captions
+    , Pandoc.Ext_tex_math_dollars
+    , Pandoc.Ext_yaml_metadata_block
     ]
 
 

--- a/lib/Patat/Theme.hs
+++ b/lib/Patat/Theme.hs
@@ -4,9 +4,9 @@
 {-# LANGUAGE TemplateHaskell            #-}
 module Patat.Theme
     ( Style (..)
-    , HeaderAlign (..)
-    , HeaderTheme (..)
-    , HeaderThemes (..)
+    , BlockAlign (..)
+    , BlockTheme (..)
+    , BlockThemes (..)
     , Theme (..)
     , defaultTheme
     , themeForHeader
@@ -23,7 +23,7 @@ import qualified Data.Aeson             as A
 import qualified Data.Aeson.TH.Extended as A
 import           Data.Char              (toLower, toUpper)
 import           Data.Colour.SRGB       (RGB (..), sRGB24reads, toSRGB24)
-import           Data.List              (intercalate, isPrefixOf, isSuffixOf)
+import           Data.List              (intercalate, isPrefixOf, isSuffixOf, foldl')
 import qualified Data.Map               as M
 import           Data.Maybe             (mapMaybe, maybeToList)
 import qualified Data.Text              as T
@@ -162,62 +162,62 @@ namedSgrs = M.fromList
 
 
 --------------------------------------------------------------------------------
-data HeaderAlign = LeftHeaderAlign | CenterHeaderAlign
+data BlockAlign = LeftBlockAlign | CenterBlockAlign
     deriving (Eq, Show)
 
 
 --------------------------------------------------------------------------------
-instance A.ToJSON HeaderAlign where
-    toJSON LeftHeaderAlign   = "left"
-    toJSON CenterHeaderAlign = "center"
+instance A.ToJSON BlockAlign where
+    toJSON LeftBlockAlign   = "left"
+    toJSON CenterBlockAlign = "center"
 
 
 --------------------------------------------------------------------------------
-instance A.FromJSON HeaderAlign where
-    parseJSON = A.withText "FromJSON HeaderAlign" $ \txt -> case txt of
-        "left"   -> pure LeftHeaderAlign
-        "center" -> pure CenterHeaderAlign
+instance A.FromJSON BlockAlign where
+    parseJSON = A.withText "FromJSON BlockAlign" $ \txt -> case txt of
+        "left"   -> pure LeftBlockAlign
+        "center" -> pure CenterBlockAlign
         _        -> fail $ "Unknown align: " ++ show txt
 
 
 --------------------------------------------------------------------------------
-data HeaderTheme = HeaderTheme
-    { htStyle     :: !(Maybe Style)
-    , htPrefix    :: !(Maybe T.Text)
-    , htUnderline :: !(Maybe T.Text)
-    , htAlign     :: !(Maybe HeaderAlign)
+data BlockTheme = BlockTheme
+    { btStyle     :: !(Maybe Style)
+    , btPrefix    :: !(Maybe T.Text)
+    , btUnderline :: !(Maybe T.Text)
+    , btAlign     :: !(Maybe BlockAlign)
     } deriving (Eq, Show)
 
 
 --------------------------------------------------------------------------------
-$(A.deriveJSON A.dropPrefixOptions ''HeaderTheme)
+$(A.deriveJSON A.dropPrefixOptions ''BlockTheme)
 
 
 --------------------------------------------------------------------------------
-instance Semigroup HeaderTheme where
-    l <> r = HeaderTheme
-        { htStyle     = htStyle     l `mplus` htStyle     r
-        , htPrefix    = htPrefix    l `mplus` htPrefix    r
-        , htUnderline = htUnderline l `mplus` htUnderline r
-        , htAlign     = htAlign     l `mplus` htAlign     r
+instance Semigroup BlockTheme where
+    l <> r = BlockTheme
+        { btStyle     = btStyle     l `mplus` btStyle     r
+        , btPrefix    = btPrefix    l `mplus` btPrefix    r
+        , btUnderline = btUnderline l `mplus` btUnderline r
+        , btAlign     = btAlign     l `mplus` btAlign     r
         }
 
 
 --------------------------------------------------------------------------------
-newtype HeaderThemes = HeaderThemes (M.Map String HeaderTheme)
+newtype BlockThemes = BlockThemes (M.Map T.Text BlockTheme)
     deriving (Eq, Show, A.FromJSON, A.ToJSON)
 
 
 --------------------------------------------------------------------------------
-instance Semigroup HeaderThemes where
-    HeaderThemes l <> HeaderThemes r = HeaderThemes $ M.unionWith (<>) l r
+instance Semigroup BlockThemes where
+    BlockThemes l <> BlockThemes r = BlockThemes $ M.unionWith (<>) l r
 
 
 --------------------------------------------------------------------------------
 data Theme = Theme
     { themeBorders            :: !(Maybe Style)
     , themeHeader             :: !(Maybe Style)
-    , themeHeaders            :: !(Maybe HeaderThemes)
+    , themeHeaders            :: !(Maybe BlockThemes)
     , themeCodeBlock          :: !(Maybe Style)
     , themeBulletList         :: !(Maybe Style)
     , themeBulletListMarkers  :: !(Maybe T.Text)
@@ -241,6 +241,7 @@ data Theme = Theme
     , themeImageText          :: !(Maybe Style)
     , themeImageTarget        :: !(Maybe Style)
     , themeSyntaxHighlighting :: !(Maybe SyntaxHighlighting)
+    , themeClass              :: !(Maybe BlockThemes)
     } deriving (Eq, Show)
 
 
@@ -273,6 +274,7 @@ instance Semigroup Theme where
         , themeImageText          = mplusOn   themeImageText
         , themeImageTarget        = mplusOn   themeImageTarget
         , themeSyntaxHighlighting = mappendOn themeSyntaxHighlighting
+        , themeClass              = mappendOn themeClass
         }
       where
         mplusOn   f = f l `mplus`   f r
@@ -285,17 +287,18 @@ instance Monoid Theme where
     mempty  = Theme
         Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
         Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
-        Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+        Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 --------------------------------------------------------------------------------
 defaultTheme :: Theme
 defaultTheme = Theme
     { themeBorders            = dull Ansi.Yellow
     , themeHeader             = dull Ansi.Blue
-    , themeHeaders            = Just $ HeaderThemes $ M.fromList $ do
+    , themeHeaders            = Just $ BlockThemes $ M.fromList $ do
         n <- [1 .. 6]
         let prefix = T.replicate n "#" <> " "
-        pure ("h" <> show n, HeaderTheme Nothing (Just prefix) Nothing Nothing)
+            key    = T.pack $ "h" <> show n
+        pure (key, BlockTheme Nothing (Just prefix) Nothing Nothing)
     , themeCodeBlock          = dull Ansi.White `mappend` ondull Ansi.Black
     , themeBulletList         = dull Ansi.Magenta
     , themeBulletListMarkers  = Just "-*"
@@ -319,6 +322,7 @@ defaultTheme = Theme
     , themeImageText          = dull Ansi.Green
     , themeImageTarget        = dull Ansi.Cyan `mappend` underline
     , themeSyntaxHighlighting = Just defaultSyntaxHighlighting
+    , themeClass              = Nothing
     }
   where
     dull   c  = Just $ Style [Ansi.SetColor Ansi.Foreground Ansi.Dull c]
@@ -328,12 +332,18 @@ defaultTheme = Theme
 
 
 --------------------------------------------------------------------------------
-themeForHeader :: Int -> Theme -> HeaderTheme
-themeForHeader n theme = maybe def (<> def) $ do
-    HeaderThemes m <- themeHeaders theme
-    M.lookup ("h" ++ show n) m
+themeForHeader :: Int -> [T.Text] -> Theme -> BlockTheme
+themeForHeader n classes theme = foldl'
+    (\acc clas -> maybe acc (<> acc) $ do
+        BlockThemes m <- themeClass theme
+        M.lookup clas m)
+    (maybe def (<> def) $ do
+        BlockThemes m <- themeHeaders theme
+        M.lookup key m)
+    classes
   where
-    def = HeaderTheme (themeHeader theme) Nothing Nothing Nothing
+    def = BlockTheme (themeHeader theme) Nothing Nothing Nothing
+    key = T.pack $ "h" <> show n
 
 
 --------------------------------------------------------------------------------

--- a/lib/Patat/Theme.hs
+++ b/lib/Patat/Theme.hs
@@ -322,7 +322,17 @@ defaultTheme = Theme
     , themeImageText          = dull Ansi.Green
     , themeImageTarget        = dull Ansi.Cyan `mappend` underline
     , themeSyntaxHighlighting = Just defaultSyntaxHighlighting
-    , themeClass              = Nothing
+    , themeClass              = Just $ BlockThemes $ M.fromList
+        [ ( "warning"
+          , BlockTheme
+              { btAlign     = Just LeftBlockAlign
+              , btPrefix    = Just "⚠ "
+              , btStyle     = Just $ Style
+                  [Ansi.SetColor Ansi.Foreground Ansi.Vivid Ansi.Red]
+              , btUnderline = Nothing
+              }
+          )
+        ]
     }
   where
     dull   c  = Just $ Style [Ansi.SetColor Ansi.Foreground Ansi.Dull c]

--- a/lib/Patat/Theme.hs
+++ b/lib/Patat/Theme.hs
@@ -323,7 +323,7 @@ defaultTheme = Theme
     , themeImageTarget        = dull Ansi.Cyan `mappend` underline
     , themeSyntaxHighlighting = Just defaultSyntaxHighlighting
     , themeClass              = Just $ BlockThemes $ M.fromList
-        [ ( "warning"
+        [ ( "alert"
           , BlockTheme
               { btAlign     = Just LeftBlockAlign
               , btPrefix    = Just "⚠ "

--- a/tests/golden/dump.in/theme-headers-class.md
+++ b/tests/golden/dump.in/theme-headers-class.md
@@ -5,9 +5,6 @@ patat:
       h2:
         underline: "=*"
     class:
-      warning:
-        prefix: "⚠ "
-        style: [vividRed]
       info:
         prefix: "💡 "
         style: [dullYellow]
@@ -26,3 +23,14 @@ The header above should mix the class and h2-based styles.
 ## Hybrid approaches {.info}
 
 Some programming languages take a hybrid approach...
+
+# Override warning
+
+<!--config:
+  theme:
+    class:
+      warning:
+        prefix: "⚠⚠⚠ "
+-->
+
+## Override the default warning with more emoji {.warning}

--- a/tests/golden/dump.in/theme-headers-class.md
+++ b/tests/golden/dump.in/theme-headers-class.md
@@ -11,12 +11,12 @@ patat:
 ...
 
 
-# Dynamically Typed Languages {.warning}
+# Dynamically Typed Languages {.alert}
 
 A dynamically typed language is a programming language where type checking is
 performed at runtime (during execution) rather than beforehand.
 
-## More information {.warning}
+## More information {.alert}
 
 The header above should mix the class and h2-based styles.
 
@@ -24,13 +24,13 @@ The header above should mix the class and h2-based styles.
 
 Some programming languages take a hybrid approach...
 
-# Override warning
+# Override alert
 
 <!--config:
   theme:
     class:
-      warning:
+      alert:
         prefix: "⚠⚠⚠ "
 -->
 
-## Override the default warning with more emoji {.warning}
+## Override the default alert with more emoji {.alert}

--- a/tests/golden/dump.in/theme-headers-class.md
+++ b/tests/golden/dump.in/theme-headers-class.md
@@ -1,0 +1,28 @@
+---
+patat:
+  theme:
+    headers:
+      h2:
+        underline: "=*"
+    class:
+      warning:
+        prefix: "⚠ "
+        style: [vividRed]
+      info:
+        prefix: "💡 "
+        style: [dullYellow]
+...
+
+
+# Dynamically Typed Languages {.warning}
+
+A dynamically typed language is a programming language where type checking is
+performed at runtime (during execution) rather than beforehand.
+
+## More information {.warning}
+
+The header above should mix the class and h2-based styles.
+
+## Hybrid approaches {.info}
+
+Some programming languages take a hybrid approach...

--- a/tests/golden/dump.out/theme-headers-class.md.dump
+++ b/tests/golden/dump.out/theme-headers-class.md.dump
@@ -1,0 +1,18 @@
+[33m                         theme-headers-class.md                         [0m
+
+[91m⚠ Dynamically Typed Languages[0m
+
+[mA dynamically typed language is a programming language where type checking is[0m
+[mperformed at runtime (during execution) rather than beforehand.[0m
+
+[91m⚠ More information[0m
+[91m=*=*=*=*=*=*=*=*=*[0m
+
+[mThe header above should mix the class and h2-based styles.[0m
+
+[33m💡 Hybrid approaches[0m
+[33m=*=*=*=*=*=*=*=*=*=*[0m
+
+[mSome programming languages take a hybrid approach...[0m
+
+[33m                                                                  1 / 1 [0m

--- a/tests/golden/dump.out/theme-headers-class.md.dump
+++ b/tests/golden/dump.out/theme-headers-class.md.dump
@@ -1,17 +1,17 @@
 [33m                         theme-headers-class.md                         [0m
 
-[34m# Dynamically Typed Languages {.alert}[0m
+[91m⚠ Dynamically Typed Languages[0m
 
 [mA dynamically typed language is a programming language where type checking is[0m
 [mperformed at runtime (during execution) rather than beforehand.[0m
 
-[34m## More information {.alert}[0m
-[34m=*=*=*=*=*=*=*=*=*=*=*=*=*=*[0m
+[91m⚠ More information[0m
+[91m=*=*=*=*=*=*=*=*=*[0m
 
 [mThe header above should mix the class and h2-based styles.[0m
 
-[34m## Hybrid approaches {.info}[0m
-[34m=*=*=*=*=*=*=*=*=*=*=*=*=*=*[0m
+[33m💡 Hybrid approaches[0m
+[33m=*=*=*=*=*=*=*=*=*=*[0m
 
 [mSome programming languages take a hybrid approach...[0m
 
@@ -22,7 +22,7 @@
 
 [34m# Override alert[0m
 
-[34m## Override the default alert with more emoji {.alert}[0m
-[34m=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*[0m
+[91m⚠⚠⚠ Override the default alert with more emoji[0m
+[91m=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*[0m
 
 [33m                                                                  2 / 2 [0m

--- a/tests/golden/dump.out/theme-headers-class.md.dump
+++ b/tests/golden/dump.out/theme-headers-class.md.dump
@@ -1,18 +1,28 @@
 [33m                         theme-headers-class.md                         [0m
 
-[91m⚠ Dynamically Typed Languages[0m
+[34m# Dynamically Typed Languages {.alert}[0m
 
 [mA dynamically typed language is a programming language where type checking is[0m
 [mperformed at runtime (during execution) rather than beforehand.[0m
 
-[91m⚠ More information[0m
-[91m=*=*=*=*=*=*=*=*=*[0m
+[34m## More information {.alert}[0m
+[34m=*=*=*=*=*=*=*=*=*=*=*=*=*=*[0m
 
 [mThe header above should mix the class and h2-based styles.[0m
 
-[33m💡 Hybrid approaches[0m
-[33m=*=*=*=*=*=*=*=*=*=*[0m
+[34m## Hybrid approaches {.info}[0m
+[34m=*=*=*=*=*=*=*=*=*=*=*=*=*=*[0m
 
 [mSome programming languages take a hybrid approach...[0m
 
-[33m                                                                  1 / 1 [0m
+[33m                                                                  1 / 2 [0m
+
+[m{slide}[0m
+[33m                         theme-headers-class.md                         [0m
+
+[34m# Override alert[0m
+
+[34m## Override the default alert with more emoji {.alert}[0m
+[34m=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*[0m
+
+[33m                                                                  2 / 2 [0m


### PR DESCRIPTION
See also #195.

This allows you to customize elements (currently only headers) with specific classes.

```markdown
---
patat:
  theme:
    class:
      alert:
        prefix: "⚠️ "
        style: [vividRed]
      info:
        prefix: "💡 "
        style: [dullYellow]
...

# Dynamically Typed Languages {.alert}

A dynamically typed language is a programming language where type checking is
performed at runtime (during execution) rather than beforehand.
```

Note that `.alert` is already included in the default theme, so that will work out of the box.